### PR TITLE
neovim: migrate nvim-treesitter to main branch for Neovim 0.12

### DIFF
--- a/.config/nvim/lua/rc/pluginconfig/nvim-treesitter-endwise.lua
+++ b/.config/nvim/lua/rc/pluginconfig/nvim-treesitter-endwise.lua
@@ -1,5 +1,2 @@
-require("nvim-treesitter.configs").setup({
-  endwise = {
-    enable = true,
-  },
-})
+-- nvim-treesitter-endwise requires no configuration in the new API.
+-- It activates automatically when loaded.

--- a/.config/nvim/lua/rc/pluginconfig/nvim-treesitter-textobjects.lua
+++ b/.config/nvim/lua/rc/pluginconfig/nvim-treesitter-textobjects.lua
@@ -1,0 +1,61 @@
+local select = require("nvim-treesitter-textobjects.select")
+local swap = require("nvim-treesitter-textobjects.swap")
+local move = require("nvim-treesitter-textobjects.move")
+
+require("nvim-treesitter-textobjects").setup({
+  select = {
+    lookahead = true,
+  },
+  move = {
+    set_jumps = true,
+  },
+})
+
+-- Select
+local select_maps = {
+  ["af"] = "@function.outer",
+  ["if"] = "@function.inner",
+  ["ac"] = "@class.outer",
+  ["ic"] = "@class.inner",
+  ["iB"] = "@block.inner",
+  ["aB"] = "@block.outer",
+  ["ii"] = "@conditional.inner",
+  ["ai"] = "@conditional.outer",
+  ["il"] = "@loop.inner",
+  ["al"] = "@loop.outer",
+  ["ip"] = "@parameter.inner",
+  ["ap"] = "@parameter.outer",
+}
+
+for lhs, capture in pairs(select_maps) do
+  vim.keymap.set({ "x", "o" }, lhs, function()
+    select.select_textobject(capture, "textobjects")
+  end, { desc = "TS " .. capture })
+end
+
+-- Swap
+vim.keymap.set("n", "'>", function()
+  swap.swap_next("@parameter.inner")
+end, { desc = "TS swap next parameter" })
+
+vim.keymap.set("n", "'<", function()
+  swap.swap_previous("@parameter.inner")
+end, { desc = "TS swap prev parameter" })
+
+-- Move
+local move_maps = {
+  { "]m", move.goto_next_start, "@function.outer" },
+  { "]M", move.goto_next_end, "@function.outer" },
+  { "]]", move.goto_next_start, "@class.outer" },
+  { "][", move.goto_next_end, "@class.outer" },
+  { "[m", move.goto_previous_start, "@function.outer" },
+  { "[M", move.goto_previous_end, "@function.outer" },
+  { "[[", move.goto_previous_start, "@class.outer" },
+  { "[]", move.goto_previous_end, "@class.outer" },
+}
+
+for _, m in ipairs(move_maps) do
+  vim.keymap.set({ "n", "x", "o" }, m[1], function()
+    m[2](m[3], "textobjects")
+  end, { desc = "TS move " .. m[3] })
+end

--- a/.config/nvim/lua/rc/pluginconfig/nvim-treesitter.lua
+++ b/.config/nvim/lua/rc/pluginconfig/nvim-treesitter.lua
@@ -1,123 +1,35 @@
-require("nvim-treesitter.install").compilers = { "clang" }
+require("nvim-treesitter").setup({})
 
-require("nvim-treesitter.configs").setup({
-  ensure_installed = {
-    "astro",
-    "bash",
-    "css",
-    "html",
-    "lua",
-    "markdown",
-    "python",
-    "ruby",
-    "tsx",
-    "typescript",
-  },
-  auto_install = true,
-  highlight = {
-    enable = true, -- false will disable the whole extension
-    disable = {}, -- list of language that will be disabled
-    additional_vim_regex_highlighting = false,
-  },
-  incremental_selection = {
-    enable = true,
-    keymaps = { -- mappings for incremental selection (visual mappings)
-      -- node_incremental = "grn", -- increment to the upper named parent
-      -- scope_incremental = "grc", -- increment to the upper scope (as defined in locals.scm)
-      -- init_selection = 'gnn', -- maps in normal mode to init the node/scope selection
-      -- node_decremental = "grm" -- decrement to the previous node
-      init_selection = "<CR>",
-      scope_incremental = "<CR>",
-      node_incremental = "<TAB>",
-      node_decremental = "<S-TAB>",
-    },
-  },
-  indent = { enable = false, disable = { "python" } },
-  refactor = {
-    highlight_definitions = { enable = false },
-    highlight_current_scope = { enable = false },
-    smart_rename = {
-      enable = true,
-      keymaps = {
-        smart_rename = "'r", -- mapping to rename reference under cursor
-      },
-    },
-    navigation = {
-      enable = true,
-      keymaps = {
-        goto_definition = "'d", -- mapping to go to definition of symbol under cursor
-        list_definitions = "'D", -- mapping to list all definitions in current file
-      },
-    },
-  },
-  textobjects = { -- syntax-aware textobjects
-    select = {
-      enable = true,
-      disable = {},
-      keymaps = {
-        ["af"] = "@function.outer",
-        ["if"] = "@function.inner",
-        ["ac"] = "@class.outer",
-        ["ic"] = "@class.inner",
-        ["iB"] = "@block.inner",
-        ["aB"] = "@block.outer",
-        -- use sandwich
-        -- ["i"] = "@call.inner",
-        -- ["a"] = "@call.outer",
-        -- ["a"] = "@comment.outer",
-        -- ["iF"] = "@frame.inner",
-        -- ["oF"] = "@frame.outer",
-        ["ii"] = "@conditional.inner",
-        ["ai"] = "@conditional.outer",
-        ["il"] = "@loop.inner",
-        ["al"] = "@loop.outer",
-        ["ip"] = "@parameter.inner",
-        ["ap"] = "@parameter.outer",
-        -- ["iS"] = "@scopename.inner",
-        -- ["aS"] = "@statement.outer",
-      },
-    },
-    swap = {
-      enable = true,
-      swap_next = { ["'>"] = "@parameter.inner" },
-      swap_previous = { ["'<"] = "@parameter.inner" },
-    },
-    move = {
-      enable = true,
-      goto_next_start = { ["]m"] = "@function.outer", ["]]"] = "@class.outer" },
-      goto_next_end = { ["]M"] = "@function.outer", ["]["] = "@class.outer" },
-      goto_previous_start = { ["[m"] = "@function.outer", ["[["] = "@class.outer" },
-      goto_previous_end = { ["[M"] = "@function.outer", ["[]"] = "@class.outer" },
-    },
-  },
-  textsubjects = {
-    enable = false,
-    -- prev_selection = "Q",
-    keymaps = {
-      ["."] = "textsubjects-smart",
-      ["<Tab>"] = "textsubjects-container-outer",
-      ["<S-Tab>"] = "textsubjects-container-inner",
-    },
-  },
-  rainbow = {
-    enable = true,
-    extended_mode = true,
-    max_file_lines = 300,
-    disable = { "cpp" }, -- please disable lua and bash for now
-  },
-  pairs = {
-    enable = false,
-    disable = {},
-    highlight_pair_events = { "CursorMoved" }, -- when to highlight the pairs, use {} to deactivate highlighting
-    highlight_self = true,
-    goto_right_end = false, -- whether to go to the end of the right partner or the beginning
-    fallback_cmd_normal = "call matchit#Match_wrapper('',1,'n')", -- What command to issue when we can't find a pair (e.g. "normal! %")
-    keymaps = { goto_partner = "'%" },
-  },
-  matchup = {
-    enable = false,
-    disable = {},
-  },
-  ts_context_commentstring = { enable = true },
-  yati = { enable = true },
+-- Install parsers (async, no-op if already installed)
+local parsers = {
+  "astro",
+  "bash",
+  "css",
+  "html",
+  "lua",
+  "markdown",
+  "python",
+  "ruby",
+  "tsx",
+  "typescript",
+}
+
+local installed = require("nvim-treesitter").installed()
+local missing = vim.tbl_filter(function(p)
+  return not vim.tbl_contains(installed, p)
+end, parsers)
+
+if #missing > 0 then
+  require("nvim-treesitter").install(missing)
+end
+
+-- Enable treesitter highlighting via Neovim built-in API
+vim.api.nvim_create_autocmd("FileType", {
+  group = vim.api.nvim_create_augroup("treesitter-highlight", { clear = true }),
+  callback = function(args)
+    if pcall(vim.treesitter.start, args.buf) then
+      -- Disable legacy regex highlighting when treesitter is active
+      vim.bo[args.buf].syntax = ""
+    end
+  end,
 })

--- a/.config/nvim/lua/rc/plugins/editing.lua
+++ b/.config/nvim/lua/rc/plugins/editing.lua
@@ -30,21 +30,23 @@ return {
   -- Treesitter & text objects
   {
     "nvim-treesitter/nvim-treesitter",
-    event = { "VeryLazy" },
-    build = ":TSUpdateSync",
+    branch = "main",
+    lazy = false,
+    build = ":TSUpdate",
     config = conf("rc/pluginconfig/nvim-treesitter"),
   },
   { "JoosepAlviste/nvim-ts-context-commentstring", lazy = true },
-  { "nvim-treesitter/nvim-treesitter-refactor", lazy = true },
-  { "nvim-treesitter/nvim-tree-docs", lazy = true },
-  { "yioneko/nvim-yati", lazy = true },
   {
     "RRethy/nvim-treesitter-endwise",
     lazy = true,
     event = "InsertEnter",
-    config = conf("rc/pluginconfig/nvim-treesitter-endwise"),
   },
-  { "nvim-treesitter/nvim-treesitter-textobjects", event = "VeryLazy" },
+  {
+    "nvim-treesitter/nvim-treesitter-textobjects",
+    branch = "main",
+    event = "VeryLazy",
+    config = conf("rc/pluginconfig/nvim-treesitter-textobjects"),
+  },
   {
     "chrisgrieser/nvim-various-textobjs",
     lazy = true,


### PR DESCRIPTION
- Switch nvim-treesitter and nvim-treesitter-textobjects to main branch
- Replace deprecated nvim-treesitter.configs.setup() with new API
- Replace ensure_installed with explicit install() calls
- Use vim.treesitter.start() for highlighting (Neovim built-in)
- Extract textobjects config into standalone setup with vim.keymap.set
- Remove deprecated plugins: nvim-treesitter-refactor, nvim-yati, nvim-tree-docs
- Remove dead module configs: rainbow, pairs, matchup, ts_context_commentstring, yati
- Incremental selection now handled by Neovim 0.12 built-in (v_an/v_in)

https://claude.ai/code/session_017aG5xLX9oLgKPPaUHURd6V