### PR TITLE
zsh: claude/codex 起動ウィジェットに ^x^a / ^x^g を追加

### DIFF
--- a/.config/zsh/rc/bindkey.zsh
+++ b/.config/zsh/rc/bindkey.zsh
@@ -20,14 +20,23 @@ bindkey '^x^c' anyframe-widget-cdr
 bindkey '^x^k' anyframe-widget-kill
 
 ## Claude ##
-function _claude-widget() { 
-  # Clear the current line and run claude
+function _claude-widget() {
   BUFFER=""
   zle accept-line
   claude
 }
 zle -N _claude-widget
-bindkey '^o' _claude-widget
+bindkey '^o'   _claude-widget
+bindkey '^x^a' _claude-widget
+
+## Codex ##
+function _codex-widget() {
+  BUFFER=""
+  zle accept-line
+  codex
+}
+zle -N _codex-widget
+bindkey '^x^g' _codex-widget
 
 ## Git ##
 function _lazygit-widget() { lazygit }


### PR DESCRIPTION
# 背景

- claude/codex を起動するキーバインドを見直したい
- `^c` のような端末予約キーや、既存の `^a` `^e` `^f` `^o` `^z` `^x^b` `^x^c` `^x^k` などと被らない割当にしたい

# 概要

- `^x^a` → claude（Anthropic）
- `^x^g` → codex（GPT 系）
- 既存の `^o` → claude は当面残し、新チョードと並走
- 検証
  - 既存 `^x` 系チョード (`^x^b/^x^c/^x^k`) と衝突なし
  - ZLE emacs キーマップのデフォルトに `^x^a` / `^x^g` は未割当
  - fzf / anyframe / zsh-autosuggestions / z-skk の既定バインドとも非干渉

```mermaid
flowchart LR
  subgraph Prefix["^x prefix (既存)"]
    B["^x^b → fzf_git_switch_branch"]
    C["^x^c → anyframe-widget-cdr"]
    K["^x^k → anyframe-widget-kill"]
  end
  subgraph New["今回追加"]
    A["^x^a → _claude-widget"]
    G["^x^g → _codex-widget"]
  end
  subgraph Single["既存 単キー"]
    O["^o → _claude-widget (併存)"]
  end
```

# 関連情報

- 対象ファイル: `.config/zsh/rc/bindkey.zsh`