### PR TITLE
zellij: Quit を Alt+q に統一

### DIFF
--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -144,7 +144,7 @@ keybinds clear-defaults=true {
         bind "Alt i" { MoveTab "left"; }
         bind "Alt n" { NewPane; }
         bind "Alt o" { MoveTab "right"; }
-        bind "Ctrl q" { Quit; }
+        bind "Alt q" { Quit; }
     }
     shared_except "locked" "move" {
         bind "Alt m" { SwitchToMode "move"; }


### PR DESCRIPTION
## 概要
前回 PR #47 で zellij の操作系を `Alt+` に全寄せした流れに沿い、最後に残っていた `Ctrl+q` (Quit) も `Alt+q` に揃える。

## 変更
- `bind "Ctrl q" { Quit; }` → `bind "Alt q" { Quit; }`

## 動作イメージ
- Ctrl+ = シェル/アプリ
- **Alt+ = zellij（Quit 含めて完全統一）**

## 検証
- [ ] `Alt+q` で zellij セッションが終了する
- [ ] `Ctrl+q` は zsh (push-line 等) に素通りする