### PR TITLE
zellij: セッション永続化を有効化

### DIFF
--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -404,14 +404,14 @@ default_mode "normal"
 //   - true (default)
 //   - false
 // 
-// session_serialization false
+session_serialization true
  
 // Whether pane viewports are serialized along with the session, default is false
 // Options:
 //   - true
 //   - false (default)
 // 
-// serialize_pane_viewport false
+serialize_pane_viewport true
  
 // Scrollback lines to serialize along with the pane viewport when serializing sessions, 0
 // defaults to the scrollback size. If this number is higher than the scrollback size, it will


### PR DESCRIPTION
## 概要
`session_serialization` と `serialize_pane_viewport` を有効化し、tmux + resurrect 相当の復元体験を得る。zellij サーバが落ちた後（マシン再起動・強制終了など）でも、タブ・ペイン配置・cwd・起動コマンド・スクロールバックが復元可能になる。

## 変更
- `session_serialization true` をコメントアウト解除
- `serialize_pane_viewport true` をコメントアウト解除
- `serialization_interval` は既定 (10000 秒) のまま、I/O は実質無視できる量

## 期待される挙動
- `zellij list-sessions` で過去の dead セッションが表示され、`zellij attach <name>` で層状に復元
- 再起動後も layout と cwd が残る
- 過去ログ（スクロールバック）も保存される

## トレードオフ（想定内）
- 定期的なディスク書き込みが発生（数 KB〜数百 KB／10000 秒程度）
- 起動コマンドが再実行される点は tmux + resurrect と同様。DB 接続や dev サーバを自動再起動されたくない場合は、そのペインを閉じてから detach するなど運用で回避

## 検証
- [ ] `zellij` を一度終了 → 再起動して `zellij list-sessions` に前セッションが残る
- [ ] `zellij attach <name>` で layout が復元される
- [ ] ペイン内のスクロール (`Alt+s`) で過去ログが取れる
- [ ] マシン再起動後も同様に復元できる