### PR TITLE
zsh: Alt+z で zellij を起動する widget を追加

### DIFF
--- a/.config/zsh/rc/bindkey.zsh
+++ b/.config/zsh/rc/bindkey.zsh
@@ -38,6 +38,15 @@ function _codex-widget() {
 zle -N _codex-widget
 bindkey '^x^g' _codex-widget
 
+## Zellij ##
+function _zellij-widget() {
+  BUFFER=""
+  zle accept-line
+  [[ -z $ZELLIJ ]] && zellij
+}
+zle -N _zellij-widget
+bindkey '^[z' _zellij-widget
+
 ## Git ##
 function _lazygit-widget() { lazygit }
 zle -N _lazygit-widget


### PR DESCRIPTION
## 概要
シェルから素早く zellij に入れるよう、`Alt+z` (`^[z`) を押すと `zellij` コマンドを実行する widget を追加する。既存の `^x^a` / `^x^g` (Claude/Codex) と同じパターン。

## 変更
`.config/zsh/rc/bindkey.zsh` に以下を追加:
```zsh
## Zellij ##
function _zellij-widget() {
  BUFFER=""
  zle accept-line
  [[ -z \$ZELLIJ ]] && zellij
}
zle -N _zellij-widget
bindkey '^[z' _zellij-widget
```

## 設計判断
- **`$ZELLIJ` 空チェック**: 既に zellij 内で `Alt+z` を押した場合の入れ子起動を防止
- **`zellij` 単体実行**: `session_serialization` が有効なので、welcome screen や `zellij list-sessions` 経由で過去セッションへ attach 可能
- **キー選定**: `^z` は既存の `zi`（補完）で埋まっているため `Alt+z` (`^[z`)。zsh emacs 既定・SKK・AquaSKK いずれも未使用で衝突なし

## 検証
- [ ] 新しい zsh 上で `Alt+z` 押下 → zellij が起動する
- [ ] コマンド入力中に `Alt+z` → `BUFFER=""` で入力がクリアされてから起動する
- [ ] zellij 内のペイン (`$ZELLIJ` が非空) で `Alt+z` → no-op（入れ子にならない）
- [ ] 既存の `^o` / `^x^a` (Claude) / `^x^g` (Codex) は従来通り動く