### PR TITLE
neovim: 取得できない registers.nvim を削除

### DIFF
--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -80,7 +80,6 @@
   "popup.nvim": { "branch": "master", "commit": "b7404d35d5d3548a82149238289fa71f7f6de4ac" },
   "promise-async": { "branch": "main", "commit": "119e8961014c9bfaf1487bf3c2a393d254f337e2" },
   "rainbow-delimiters.nvim": { "branch": "master", "commit": "08783ec022e7ddefe0f12a16f1ac4968f55478b0" },
-  "registers.nvim": { "branch": "main", "commit": "c217f8f369e0886776cda6c94eab839b30a8940d" },
   "render-markdown.nvim": { "branch": "main", "commit": "d67113f11384c0dad96fced2f7b91f1fc811e97f" },
   "sidebar.nvim": { "branch": "main", "commit": "082e4903c1659a65e27a075b752178b0c56fffb2" },
   "skkeleton": { "branch": "main", "commit": "b530eac5a859ce2f8fa4d99fa5cd83b9d3199086" },

--- a/.config/nvim/lua/rc/pluginconfig/nvim-treesitter-endwise.lua
+++ b/.config/nvim/lua/rc/pluginconfig/nvim-treesitter-endwise.lua
@@ -1,2 +1,0 @@
--- nvim-treesitter-endwise requires no configuration in the new API.
--- It activates automatically when loaded.

--- a/.config/nvim/lua/rc/pluginconfig/registers.lua
+++ b/.config/nvim/lua/rc/pluginconfig/registers.lua
@@ -1,6 +1,0 @@
-local registers = require("registers")
-registers.setup({
-  bind_keys = {
-    normal = false,
-  },
-})

--- a/.config/nvim/lua/rc/plugins/editing.lua
+++ b/.config/nvim/lua/rc/plugins/editing.lua
@@ -9,11 +9,6 @@ return {
     event = "VeryLazy",
     config = conf("rc/pluginconfig/yanky"),
   },
-  {
-    "tversteeg/registers.nvim",
-    event = "VeryLazy",
-    config = conf("rc/pluginconfig/registers"),
-  },
 
   -- Search / filer
   {


### PR DESCRIPTION
## 概要
- 取得できなくなっている `tversteeg/registers.nvim` の plugin 定義を削除
- `registers.nvim` と未参照だった `nvim-treesitter-endwise` の不要な pluginconfig を削除
- `lazy-lock.json` から `registers.nvim` の lock entry を削除

## 確認
- `stylua --check .config/nvim/lua/rc/plugins/editing.lua`
- `rg -n "registers\\.nvim|rc/pluginconfig/registers|nvim-treesitter-endwise\\.lua" .config/nvim`
- `git diff --cached --check`
- `nvim --headless "+lua local lazy=require('lazy.core.config').plugins; if lazy['registers.nvim'] then error('registers.nvim still configured') end" +qa`

## 補足
- `lazy-lock.json` には作業前から別 plugin の更新差分がありましたが、この PR には `registers.nvim` の削除だけを含めています。
