### PR TITLE
starship: hide phantom untracked symbol & cleanup fishline gitlink

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -63,6 +63,9 @@ ahead = '⇡${count}'
 diverged = '⇕⇡${ahead_count}⇣${behind_count}'
 behind = '⇣${count}'
 staged = '[++\($count\)](fg: #0abf53, bg: #394260)'
+# libgit2 (used by starship) reports phantom untracked entries due to differences
+# in .gitignore handling vs git CLI; suppress the noisy `?` symbol.
+untracked = ''
 
 [nodejs]
 symbol = ""


### PR DESCRIPTION
# 背景

zsh の Starship プロンプトで `master` の横に `?` が常に表示されていた。`git status` はクリーンなのに `?` が消えない状態。

調査の結果、以下 2 件の独立した問題が見つかった:

1. **Starship が `?` を表示する根本原因**: Starship 内部の libgit2 が、git CLI とは異なる `.gitignore` 解釈で「untracked」と誤判定するファイルを拾ってしまう。git CLI 上は `git ls-files --others --exclude-standard` も空、`git status` も clean。
2. **壊れたサブモジュール参照**: `.config/fish/fishline` が gitlink (`160000`) として index に残っているが、`.gitmodules` ファイルが存在しないため `git submodule status` が `fatal: no submodule mapping found` エラーを出していた。

# 概要

## 1. `starship: hide untracked symbol in git_status`

`.config/starship.toml` の `[git_status]` で `untracked = ''` を設定し、libgit2 由来のノイズを抑制。`staged` / `ahead` / `behind` / `diverged` の表示は維持。

## 2. `fish: remove dangling fishline submodule`

`git rm --cached .config/fish/fishline` で宙ぶらりんの gitlink を削除し、空ディレクトリも削除。`?` 問題とは無関係だが、調査中に見つかった独立クリーンアップ。

```mermaid
flowchart LR
    A[Starship prompt with ?] --> B{原因調査}
    B --> C[libgit2 vs git CLI<br/>.gitignore 解釈差]
    B --> D[壊れた fishline gitlink<br/>※調査中に発見した別件]
    C --> E[starship.toml で<br/>untracked = '' を設定]
    D --> F[git rm --cached で削除]
    E --> G[? が消える]
    F --> H[git submodule status の<br/>エラーが消える]
```

# 動作確認

```
$ starship module git_status
（空 — 以前は `?` が表示されていた）

$ git submodule status
（空 — 以前は fatal エラー）

$ git status
On branch fish/remove-fishline-submodule
nothing to commit, working tree clean
```

# 関連情報

- Starship `git_status` 設定: https://starship.rs/config/#git-status
