### PR TITLE
neovim: 起動時ロードをチューニング

### DIFF
--- a/.config/nvim/lua/rc/keymaps/util.lua
+++ b/.config/nvim/lua/rc/keymaps/util.lua
@@ -5,16 +5,7 @@ local M = {}
 function M.set(maps)
   for _, map in ipairs(maps) do
     local mode, lhs, rhs, opts = map[1], map[2], map[3], map[4] or {}
-    local plugin = opts.plugin
     opts.plugin = nil
-
-    -- プラグイン名が指定されている場合は、定義時に lazy.nvim で読み込んでおく
-    if plugin then
-      local ok, lazy = pcall(require, "lazy")
-      if ok and lazy and lazy.load then
-        lazy.load({ plugins = { plugin } })
-      end
-    end
 
     vim.keymap.set(mode, lhs, rhs, opts)
   end

--- a/.config/nvim/lua/rc/lsp/init.lua
+++ b/.config/nvim/lua/rc/lsp/init.lua
@@ -15,8 +15,20 @@ local function ensure_state_home()
   end
 end
 
+local function truncate_large_lsp_log()
+  local max_size = 10 * 1024 * 1024
+  local log_path = vim.lsp.log.get_filename()
+  local stat = vim.uv.fs_stat(log_path)
+
+  if stat and stat.size > max_size then
+    vim.fn.writefile({}, log_path)
+  end
+end
+
 function M.setup()
   ensure_state_home()
+  vim.lsp.log.set_level(vim.lsp.log.levels.ERROR)
+  truncate_large_lsp_log()
   diagnostic.setup()
   attach.setup_autocmd()
 

--- a/.config/nvim/lua/rc/plugins/lsp.lua
+++ b/.config/nvim/lua/rc/plugins/lsp.lua
@@ -76,14 +76,16 @@ return {
   },
   {
     "williamboman/mason-lspconfig.nvim",
-    dependencies = { "williamboman/mason.nvim" },
-    event = { "BufReadPre", "BufNewFile" },
+    dependencies = {
+      "williamboman/mason.nvim",
+      "neovim/nvim-lspconfig",
+    },
+    event = "VeryLazy",
     config = conf("rc/lsp"),
   },
   {
     "neovim/nvim-lspconfig",
-    dependencies = { "williamboman/mason-lspconfig.nvim" },
-    event = { "BufReadPre", "BufNewFile" },
+    lazy = true,
     config = false,
   },
   {
@@ -99,7 +101,10 @@ return {
   -- LSP UI
   {
     "nvimdev/lspsaga.nvim",
-    event = "VeryLazy",
+    cmd = {
+      "Lspsaga",
+      "LSoutlineToggle",
+    },
     config = conf("rc/pluginconfig/lspsaga"),
   },
   {
@@ -110,7 +115,7 @@ return {
   {
     "j-hui/fidget.nvim",
     tag = "legacy",
-    event = "BufEnter",
+    event = "LspAttach",
     config = conf("rc/pluginconfig/fidget"),
   },
 

--- a/.config/nvim/lua/rc/plugins/tools.lua
+++ b/.config/nvim/lua/rc/plugins/tools.lua
@@ -12,7 +12,6 @@ return {
   },
   {
     "danymat/neogen",
-    event = "VeryLazy",
     config = conf("rc/pluginconfig/neogen"),
   },
   {
@@ -23,6 +22,7 @@ return {
       { "delphinus/budoux.lua", version = "*" },
     },
     ft = { "markdown" },
+    cmd = { "MdRender", "MdRenderTab" },
   },
   {
     "MeanderingProgrammer/render-markdown.nvim",
@@ -51,7 +51,7 @@ return {
   { "akinsho/git-conflict.nvim", event = "BufReadPre" },
   {
     "lewis6991/gitsigns.nvim",
-    event = { "BufReadPre", "BufNewFile" },
+    event = "VeryLazy",
     config = conf("rc/pluginconfig/gitsigns"),
   },
   {
@@ -68,7 +68,7 @@ return {
   -- Terminal / file explorer
   {
     "akinsho/toggleterm.nvim",
-    event = "VeryLazy",
+    cmd = "ToggleTerm",
     config = conf("rc/pluginconfig/toggleterm"),
   },
   {

--- a/.config/nvim/lua/rc/plugins/ui.lua
+++ b/.config/nvim/lua/rc/plugins/ui.lua
@@ -18,7 +18,7 @@ return {
   },
   {
     "folke/snacks.nvim",
-    event = "VeryLazy",
+    lazy = false,
     config = conf("rc/pluginconfig/snacks"),
   },
 
@@ -40,12 +40,12 @@ return {
   },
   {
     "RRethy/vim-illuminate",
-    event = "BufReadPost",
+    event = "VeryLazy",
     config = conf("rc/pluginconfig/vim-illuminate"),
   },
   {
     "norcalli/nvim-colorizer.lua",
-    event = { "BufReadPost", "BufNewFile" },
+    event = "VeryLazy",
     config = function()
       require("colorizer").setup()
     end,
@@ -78,7 +78,6 @@ return {
     dependencies = {
       "kevinhwang91/promise-async",
     },
-    event = "BufReadPost",
     config = conf("rc/pluginconfig/nvim-ufo"),
   },
 
@@ -90,7 +89,14 @@ return {
   },
   {
     "akinsho/bufferline.nvim",
-    event = "VeryLazy",
+    cmd = {
+      "BufferLinePick",
+      "BufferLineCyclePrev",
+      "BufferLineCycleNext",
+      "BufferLineMovePrev",
+      "BufferLineMoveNext",
+      "BufferLineGoToBuffer",
+    },
     dependencies = { "nvim-tree/nvim-web-devicons" },
     config = conf("rc/pluginconfig/bufferline"),
   },

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -63,11 +63,12 @@ eval "$(direnv hook zsh)"
 #--------------------------------------------------------------#
 DOCKER_PRUNE_MARKER="$HOME/.docker_last_prune"
 if [[ ! -f "$DOCKER_PRUNE_MARKER" ]] || [[ $(find "$DOCKER_PRUNE_MARKER" -mtime +7 2>/dev/null) ]]; then
-  if docker info &>/dev/null; then
-    echo "Docker cleanup (7+ days old resources)..."
-    docker system prune -f --filter "until=168h" 2>/dev/null
-    touch "$DOCKER_PRUNE_MARKER"
-  fi
+  {
+    if docker info &>/dev/null; then
+      docker system prune -f --filter "until=168h" >/dev/null 2>&1
+      touch "$DOCKER_PRUNE_MARKER"
+    fi
+  } &!
 fi
 
 # pnpm

--- a/.config/zsh/rc/pluginlist.zsh
+++ b/.config/zsh/rc/pluginlist.zsh
@@ -84,6 +84,6 @@ eval "$(zoxide init zsh)"
 #--------------------------------#
 # gwq completion
 #--------------------------------#
-if command -v gwq &>/dev/null; then
+if (( ${+functions[compdef]} )) && command -v gwq &>/dev/null; then
   source <(gwq completion zsh)
 fi


### PR DESCRIPTION
## 概要
- Neovim の keymap 定義時に lazy.nvim plugin を強制ロードしないよう変更
- 重い plugin を cmd / VeryLazy / LspAttach トリガーへ寄せて起動時ロードを削減
- dashboard 表示のラグを避けるため snacks.nvim は起動時ロードに維持
- LSP ログ肥大化対策としてログレベルを ERROR にし、10MB 超過時に truncate
- zsh の gwq completion の compdef エラーを抑制し、Docker cleanup をバックグラウンド化

## 確認
- stylua --check .config/nvim
- zsh -n .config/zsh/.zshrc
- zsh -n .config/zsh/rc/pluginlist.zsh
- nvim --headless +'lua print(vim.fn.exists(":BufferLinePick"), vim.fn.exists(":Lspsaga"), vim.fn.exists(":ToggleTerm"), vim.fn.exists(":Octo"), vim.fn.exists(":MdRender"))' +qa
- nvim --startuptime /tmp/nvim-startuptime.log --headless +qa: NVIM STARTED 28ms
- nvim --startuptime /tmp/nvim-startuptime-file.log --headless .config/nvim/init.lua +qa: NVIM STARTED 50ms