### PR TITLE
neovim: nvim-ghost を削除

### DIFF
--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -59,7 +59,6 @@
   "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
   "nvim-colorizer.lua": { "branch": "master", "commit": "a065833f35a3a7cc3ef137ac88b5381da2ba302e" },
   "nvim-cursorword": { "branch": "master", "commit": "c0f2958ec729b47be2dba0d79ef43d005dac9f4e" },
-  "nvim-ghost.nvim": { "branch": "main", "commit": "bdba2a8ad0eec84379d65e7aa9b76a17b11b653a" },
   "nvim-hlslens": { "branch": "main", "commit": "be2d7b2be01860b5445a007ff2bc72b29896db6b" },
   "nvim-lint": { "branch": "master", "commit": "eab58b48eb11d7745c11c505e0f3057165902461" },
   "nvim-lsp-smag": { "branch": "master", "commit": "add830cb376ebe3daac3f63b7f4349c499090918" },

--- a/.config/nvim/lua/rc/pluginconfig/nvim-ghost.lua
+++ b/.config/nvim/lua/rc/pluginconfig/nvim-ghost.lua
@@ -1,7 +1,0 @@
-vim.g.nvim_ghost_server_port = 4001
-vim.cmd([[
-  augroup nvim_ghost_user_autocommands
-    autocmd User *github.com setfiletype markdown
-    autocmd User *openai.com setfiletype markdown
-  augroup END
-]])

--- a/.config/nvim/lua/rc/plugins/tools.lua
+++ b/.config/nvim/lua/rc/plugins/tools.lua
@@ -127,13 +127,6 @@ return {
     config = conf("rc/pluginconfig/codex"),
   },
 
-  -- Browser support
-  {
-    "subnut/nvim-ghost.nvim",
-    event = "VeryLazy",
-    config = conf("rc/pluginconfig/nvim-ghost"),
-  },
-
   -- Analyzer
   { "wakatime/vim-wakatime", event = "VeryLazy" },
 


### PR DESCRIPTION
## 概要
- `subnut/nvim-ghost.nvim` の plugin spec を削除
- `rc/pluginconfig/nvim-ghost.lua` を削除
- `lazy-lock.json` から `nvim-ghost.nvim` を削除

## 確認
- `stylua --check .config/nvim`
- `nvim --headless +qa`
- `rg "nvim-ghost|nvim_ghost" .config/nvim -n` で参照なし