### PR TITLE
skk: fix launch agent path resolution

### DIFF
--- a/.config/skk/launch/com.user.yaskkserv2.plist
+++ b/.config/skk/launch/com.user.yaskkserv2.plist
@@ -4,7 +4,7 @@
   <key>Label</key>            <string>com.user.yaskkserv2</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/Users/$USER/.dotfiles/skk/update-dictionary.zsh</string>
+    <string>@HOME@/dotfiles/.config/skk/update-dictionary.zsh</string>
   </array>
   <key>KeepAlive</key>        <true/>
   <key>RunAtLoad</key>        <true/>

--- a/install_scripts/lib/dotinstaller/install-skk.sh
+++ b/install_scripts/lib/dotinstaller/install-skk.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ue
+
 # install yaskkserv2
 # Supply-chain hardening: pin to a specific release tag
 if ! command -v yaskkserv2 >/dev/null 2>&1; then
@@ -7,6 +9,12 @@ if ! command -v yaskkserv2 >/dev/null 2>&1; then
 fi
 
 # setup launch agent
-ln -sf ~/.dotfiles/skk/launch/com.user.yaskkserv2.plist \
-  ~/Library/LaunchAgents/com.user.yaskkserv2.plist
-launchctl load -w ~/Library/LaunchAgents/com.user.yaskkserv2.plist
+# plist <string> does not expand env vars or ~, so render @HOME@ at install time
+src="$HOME/dotfiles/.config/skk/launch/com.user.yaskkserv2.plist"
+dest="$HOME/Library/LaunchAgents/com.user.yaskkserv2.plist"
+
+mkdir -p "$(dirname "$dest")"
+sed "s|@HOME@|$HOME|g" "$src" > "$dest"
+
+launchctl unload "$dest" 2>/dev/null || true
+launchctl load -w "$dest"


### PR DESCRIPTION
## Summary
- `.config/skk/launch/com.user.yaskkserv2.plist` の `ProgramArguments` が `/Users/$USER/.dotfiles/skk/update-dictionary.zsh` を参照していたが、plist の `<string>` 内では環境変数 (`$USER`) は展開されず、しかもパス自体が誤り (`.dotfiles/skk` → 実際は `dotfiles/.config/skk`) で launchd エージェントが起動できない状態だった。
- `install_scripts/lib/dotinstaller/install-skk.sh` も同様に存在しない `~/.dotfiles/skk/launch/...` を symlink しようとしていた。
- plist 側を `@HOME@` プレースホルダに変更し、`install-skk.sh` がインストール時に `sed` で実 HOME を展開して `~/Library/LaunchAgents/` へ書き出す方式へ変更。あわせて `set -ue` と `launchctl unload` での冪等化も追加。

## Background
プロジェクト全体のセキュリティレビュー (`/security-review`) でセキュリティ上の脆弱性は無かったが、副次的に上記 2 つのパス不整合 (機能不全のバグ) が見つかったため修正。

## Test plan
- [x] `plutil -lint` でレンダリング後の plist が valid XML になることを確認
- [x] `sed "s|@HOME@|$HOME|g"` の出力に `/Users/<user>/dotfiles/.config/skk/update-dictionary.zsh` が含まれ、ファイルが実在することを確認
- [ ] (手動) `bash install_scripts/lib/dotinstaller/install-skk.sh` を実行し、`launchctl list | grep yaskkserv2` で agent が登録されることを確認