### PR TITLE
neovim: image.nvim の rockspec ビルドを無効化

### DIFF
--- a/.config/nvim/lua/rc/plugins/tools.lua
+++ b/.config/nvim/lua/rc/plugins/tools.lua
@@ -133,6 +133,10 @@ return {
   -- GUI / media
   {
     "3rd/image.nvim",
+    build = false,
     ft = { "markdown", "norg", "org", "text" },
+    opts = {
+      processor = "magick_cli",
+    },
   },
 }


### PR DESCRIPTION
# 背景

- `Lazy update` で `image.nvim` の rockspec ビルドが走り、Lua 5.1 が見つからない警告が出ていた。
- `image.nvim` はデフォルトの `magick_cli` processor で利用できるため、LuaRocks の `magick` rock をビルドする必要がない。

# 概要

- `image.nvim` の `build` を `false` にして、Lazy update 時の rockspec ビルドを無効化。
- `processor = "magick_cli"` を明示して、ImageMagick CLI を使う構成に固定。

# 関連情報

- なし

# 確認方法

- `stylua --check .config/nvim/lua/rc/plugins/tools.lua`
- `nvim --headless +qa`
- `nvim --headless '+lua local p=require("lazy.core.config").plugins["image.nvim"]; print(vim.inspect({ build = p and p.build, opts = p and p.opts }))' +qa`
- `nvim --headless '+checkhealth lazy' '+qa'`
