### PR TITLE
neovim: Markdown previewを分割表示にする

### DIFF
--- a/.config/nvim/lua/rc/keymaps/plugins.lua
+++ b/.config/nvim/lua/rc/keymaps/plugins.lua
@@ -282,7 +282,17 @@ return function()
 
     ------------------------------------------------------------
     -- Markdown
-    { "n", "<Leader>mo", "<Cmd>MdRender<CR>", { noremap = true, silent = true, plugin = "md-render.nvim" } },
+    {
+      "n",
+      "<Leader>mo",
+      function()
+        local width = vim.api.nvim_win_get_width(0)
+        local height = vim.api.nvim_win_get_height(0)
+        local mods = width >= height and { vertical = true } or {}
+        require("md-render").preview.split({ mods = mods })
+      end,
+      { noremap = true, silent = true, plugin = "md-render.nvim" },
+    },
     { "n", "<Leader>mt", "<Cmd>MdRenderTab<CR>", { noremap = true, silent = true, plugin = "md-render.nvim" } },
 
     ------------------------------------------------------------


### PR DESCRIPTION
# 背景

- `MdRender` のフローティングプレビューは表示専用で直接編集できないため、Markdown 編集時は source/render を並べて見られるほうが扱いやすい。
- `md-render.nvim` は `MdRenderSplit` 相当の API を提供しているため、既存の `<Leader>mo` を分割プレビューに寄せる。

# 概要

- `<Leader>mo` を `:MdRender` の中央フロート表示から `require("md-render").preview.split()` に変更。
- 現在ウィンドウの横幅が高さ以上なら左右分割、縦が長い場合は上下分割にする。
- `<Leader>mt` のタブプレビューは既存のまま維持。

# Mermaid 調査メモ

- `mmdc --version` は `11.12.0`。
- サンドボックス外では `mmdc` による PNG 生成と `md-render.image.render_mermaid()` のキャッシュ生成は成功。
- Codex サンドボックス内では Chromium/Puppeteer の起動が `sandbox_parameters_mac.mm` で失敗したため、サンドボックス環境では `Rendering mermaid diagram...` のまま残りうる。
- 通常の Neovim 実行環境で同じ状態になる場合は、`mmdc` 実行時の Chromium 起動エラー、または Kitty graphics protocol 対応ターミナル/TTY 検出の失敗を疑う。

# 確認方法

- `stylua .config/nvim/lua/rc/keymaps/plugins.lua --check`
- `git diff --check`
- `env XDG_CACHE_HOME=/private/tmp/nvim-cache XDG_STATE_HOME=/private/tmp/nvim-state nvim --headless --clean -c 'set rtp+=/private/tmp/dotfiles-md-render-adaptive-split/.config/nvim' -c 'luafile /private/tmp/dotfiles-md-render-adaptive-split/.config/nvim/lua/rc/keymaps/plugins.lua' -c qa`
- `mmdc -i /private/tmp/md-render-test.mmd -o /private/tmp/md-render-test.png -t dark -b '#1e1e2e' -s 2`
- `nvim --headless --clean -c 'set rtp+=/Users/urugus/.local/share/nvim/lazy/md-render.nvim' -c 'lua local img=require("md-render.image"); local path=img.render_mermaid("flowchart TD\n  A-->B"); print(vim.inspect({has_mmdc=img.has_mmdc(), path=path}))' -c qa`

補足: フル config の headless 起動は Codex サンドボックスが `~/.cache/nvim` / ShaDa への書き込みを許可しないため未実施。
