### PR TITLE
neovim: LSP の初回 attach を修正

### DIFF
--- a/.config/nvim/lua/rc/plugins/lsp.lua
+++ b/.config/nvim/lua/rc/plugins/lsp.lua
@@ -71,7 +71,7 @@ return {
   -- LSP core
   {
     "folke/neoconf.nvim",
-    event = "VeryLazy",
+    event = { "BufReadPre", "BufNewFile" },
     config = conf("rc/pluginconfig/neoconf"),
   },
   {

--- a/.config/nvim/lua/rc/plugins/lsp.lua
+++ b/.config/nvim/lua/rc/plugins/lsp.lua
@@ -80,7 +80,7 @@ return {
       "williamboman/mason.nvim",
       "neovim/nvim-lspconfig",
     },
-    event = "VeryLazy",
+    event = { "BufReadPre", "BufNewFile" },
     config = conf("rc/lsp"),
   },
   {


### PR DESCRIPTION
# 背景

- Neovim 起動時に最初から開いているファイルへ LSP が attach されない状態でした。
- LSP 初期化が `VeryLazy` で走っており、`FileType` の後に `vim.lsp.enable()` されるため、初回バッファが取りこぼされていました。

# 概要

- `mason-lspconfig.nvim` のロードタイミングを `BufReadPre` / `BufNewFile` に変更しました。
- ファイル読み込み前に LSP 設定を有効化し、最初に開いたファイルでも LSP が attach されるようにしました。

# 関連情報

- Jira issue: なし

# 確認方法

- `stylua --check .config/nvim/lua/rc/plugins/lsp.lua`
- `nvim --headless .config/nvim/lua/rc/lsp/init.lua '+lua vim.defer_fn(function() local clients=vim.lsp.get_clients({bufnr=0}); print("client_count", #clients); for _, c in ipairs(clients) do print("client", c.name) end; vim.cmd("qa") end, 3000)'`
  - `client_count 3`
  - `lua_ls`, `stylua`, `typos_lsp` が attach することを確認
