### PR TITLE
neovim: LSP 起動と定義ジャンプを修正

### DIFF
--- a/.config/nvim/lua/rc/keymaps/plugins.lua
+++ b/.config/nvim/lua/rc/keymaps/plugins.lua
@@ -1,5 +1,25 @@
 local set = require("rc.keymaps.util").set
 
+local function jump_to_first_location(opts)
+  local item = opts.items and opts.items[1]
+  if not item then
+    return
+  end
+
+  if item.filename then
+    vim.cmd.edit(vim.fn.fnameescape(item.filename))
+  end
+  if item.lnum and item.col then
+    vim.api.nvim_win_set_cursor(0, { item.lnum, math.max(item.col - 1, 0) })
+  end
+end
+
+local function lsp_location(fn)
+  return function()
+    fn({ on_list = jump_to_first_location })
+  end
+end
+
 return function()
   set({
     -- プレフィックス
@@ -120,31 +140,33 @@ return function()
     {
       "n",
       "gd",
-      vim.lsp.buf.definition,
+      lsp_location(vim.lsp.buf.definition),
       { noremap = true, silent = true },
     },
     {
       "n",
       "gD",
-      vim.lsp.buf.declaration,
+      lsp_location(vim.lsp.buf.declaration),
       { noremap = true, silent = true },
     },
     {
       "n",
       "gr",
-      vim.lsp.buf.references,
+      function()
+        vim.lsp.buf.references(nil, { on_list = jump_to_first_location })
+      end,
       { noremap = true, silent = true },
     },
     {
       "n",
       "gI",
-      vim.lsp.buf.implementation,
+      lsp_location(vim.lsp.buf.implementation),
       { noremap = true, silent = true },
     },
     {
       "n",
       "gy",
-      vim.lsp.buf.type_definition,
+      lsp_location(vim.lsp.buf.type_definition),
       { noremap = true, silent = true },
     },
 

--- a/.config/nvim/lua/rc/keymaps/plugins.lua
+++ b/.config/nvim/lua/rc/keymaps/plugins.lua
@@ -120,9 +120,7 @@ return function()
     {
       "n",
       "gd",
-      function()
-        require("snacks").picker.lsp_definitions({ include_current = true })
-      end,
+      vim.lsp.buf.definition,
       { noremap = true, silent = true, plugin = "snacks.nvim" },
     },
     {

--- a/.config/nvim/lua/rc/keymaps/plugins.lua
+++ b/.config/nvim/lua/rc/keymaps/plugins.lua
@@ -116,44 +116,36 @@ return function()
     { "n", "[Octo]rc", "<Cmd>Octo review comments<Cr>", { silent = true, noremap = true, plugin = "octo.nvim" } },
 
     ------------------------------------------------------------
-    -- LSP (Snacks picker)
+    -- LSP
     {
       "n",
       "gd",
       vim.lsp.buf.definition,
-      { noremap = true, silent = true, plugin = "snacks.nvim" },
+      { noremap = true, silent = true },
     },
     {
       "n",
       "gD",
-      function()
-        require("snacks").picker.lsp_declarations()
-      end,
-      { noremap = true, silent = true, plugin = "snacks.nvim" },
+      vim.lsp.buf.declaration,
+      { noremap = true, silent = true },
     },
     {
       "n",
       "gr",
-      function()
-        require("snacks").picker.lsp_references()
-      end,
-      { noremap = true, silent = true, plugin = "snacks.nvim" },
+      vim.lsp.buf.references,
+      { noremap = true, silent = true },
     },
     {
       "n",
       "gI",
-      function()
-        require("snacks").picker.lsp_implementations()
-      end,
-      { noremap = true, silent = true, plugin = "snacks.nvim" },
+      vim.lsp.buf.implementation,
+      { noremap = true, silent = true },
     },
     {
       "n",
       "gy",
-      function()
-        require("snacks").picker.lsp_type_definitions()
-      end,
-      { noremap = true, silent = true, plugin = "snacks.nvim" },
+      vim.lsp.buf.type_definition,
+      { noremap = true, silent = true },
     },
 
     ------------------------------------------------------------

--- a/.config/nvim/lua/rc/keymaps/plugins.lua
+++ b/.config/nvim/lua/rc/keymaps/plugins.lua
@@ -1,12 +1,34 @@
 local set = require("rc.keymaps.util").set
 
-local function first_lsp_location(result)
+local function snake_case(value)
+  return value:gsub("::", "/"):gsub("([A-Z]+)([A-Z][a-z])", "%1_%2"):gsub("([a-z%d])([A-Z])", "%1_%2"):lower()
+end
+
+local function lsp_location_uri(location)
+  return location.uri or location.targetUri
+end
+
+local function lsp_location_path(location)
+  local uri = lsp_location_uri(location)
+  return uri and vim.uri_to_fname(uri) or nil
+end
+
+local function best_lsp_location(result)
   if not result then
     return nil
   end
   if result.uri or result.targetUri then
     return result
   end
+
+  local symbol_path = snake_case(vim.fn.expand("<cword>")) .. ".rb"
+  for _, location in ipairs(result) do
+    local path = lsp_location_path(location)
+    if path and path:sub(-#symbol_path) == symbol_path then
+      return location
+    end
+  end
+
   return result[1]
 end
 
@@ -48,7 +70,7 @@ local function lsp_location(method, extend_params)
           return
         end
 
-        local location = first_lsp_location(result)
+        local location = best_lsp_location(result)
         if not location then
           return
         end

--- a/.config/nvim/lua/rc/keymaps/plugins.lua
+++ b/.config/nvim/lua/rc/keymaps/plugins.lua
@@ -1,22 +1,62 @@
 local set = require("rc.keymaps.util").set
 
-local function jump_to_first_location(opts)
-  local item = opts.items and opts.items[1]
-  if not item then
-    return
+local function first_lsp_location(result)
+  if not result then
+    return nil
   end
-
-  if item.filename then
-    vim.cmd.edit(vim.fn.fnameescape(item.filename))
+  if result.uri or result.targetUri then
+    return result
   end
-  if item.lnum and item.col then
-    vim.api.nvim_win_set_cursor(0, { item.lnum, math.max(item.col - 1, 0) })
-  end
+  return result[1]
 end
 
-local function lsp_location(fn)
+local function jump_to_lsp_location(location, client_id)
+  local client = vim.lsp.get_client_by_id(client_id)
+  local offset_encoding = client and client.offset_encoding or "utf-16"
+
+  if location.targetUri then
+    location = {
+      uri = location.targetUri,
+      range = location.targetSelectionRange or location.targetRange,
+    }
+  end
+
+  vim.lsp.util.jump_to_location(location, offset_encoding, true)
+end
+
+local function lsp_location(method, extend_params)
   return function()
-    fn({ on_list = jump_to_first_location })
+    local clients = vim.tbl_filter(function(client)
+      return client:supports_method(method, 0)
+    end, vim.lsp.get_clients({ bufnr = 0 }))
+    local client = clients[1]
+    if not client then
+      return
+    end
+
+    local offset_encoding = client and client.offset_encoding or "utf-16"
+    local params = vim.lsp.util.make_position_params(0, offset_encoding)
+    local jumped = false
+
+    if extend_params then
+      extend_params(params)
+    end
+
+    for _, lsp_client in ipairs(clients) do
+      lsp_client:request(method, params, function(err, result, ctx)
+        if jumped or err then
+          return
+        end
+
+        local location = first_lsp_location(result)
+        if not location then
+          return
+        end
+
+        jumped = true
+        jump_to_lsp_location(location, ctx.client_id)
+      end, 0)
+    end
   end
 end
 
@@ -140,33 +180,33 @@ return function()
     {
       "n",
       "gd",
-      lsp_location(vim.lsp.buf.definition),
+      lsp_location("textDocument/definition"),
       { noremap = true, silent = true },
     },
     {
       "n",
       "gD",
-      lsp_location(vim.lsp.buf.declaration),
+      lsp_location("textDocument/declaration"),
       { noremap = true, silent = true },
     },
     {
       "n",
       "gr",
-      function()
-        vim.lsp.buf.references(nil, { on_list = jump_to_first_location })
-      end,
+      lsp_location("textDocument/references", function(params)
+        params.context = { includeDeclaration = true }
+      end),
       { noremap = true, silent = true },
     },
     {
       "n",
       "gI",
-      lsp_location(vim.lsp.buf.implementation),
+      lsp_location("textDocument/implementation"),
       { noremap = true, silent = true },
     },
     {
       "n",
       "gy",
-      lsp_location(vim.lsp.buf.type_definition),
+      lsp_location("textDocument/typeDefinition"),
       { noremap = true, silent = true },
     },
 

--- a/.config/nvim/lua/rc/keymaps/plugins.lua
+++ b/.config/nvim/lua/rc/keymaps/plugins.lua
@@ -121,7 +121,7 @@ return function()
       "n",
       "gd",
       function()
-        require("snacks").picker.lsp_definitions()
+        require("snacks").picker.lsp_definitions({ include_current = true })
       end,
       { noremap = true, silent = true, plugin = "snacks.nvim" },
     },

--- a/.config/nvim/lua/rc/lsp/init.lua
+++ b/.config/nvim/lua/rc/lsp/init.lua
@@ -35,6 +35,7 @@ function M.setup()
   require("mason").setup()
   require("mason-lspconfig").setup({
     ensure_installed = servers.ensure_installed,
+    automatic_enable = false,
   })
 
   servers.setup(capabilities.get())

--- a/.config/solargraph/config.yml
+++ b/.config/solargraph/config.yml
@@ -1,0 +1,42 @@
+---
+include:
+  - Rakefile
+  - Gemfile
+  - "*.gemspec"
+  - "**/*.rb"
+exclude:
+  - spec/**/*
+  - "**/spec/**/*"
+  - test/**/*
+  - "**/test/**/*"
+  - vendor/**/*
+  - "**/vendor/**/*"
+  - _build/**/*
+  - "**/_build/**/*"
+  - node_modules/**/*
+  - "**/node_modules/**/*"
+  - coverage/**/*
+  - "**/coverage/**/*"
+  - log/**/*
+  - "**/log/**/*"
+  - tmp/**/*
+  - "**/tmp/**/*"
+  - .bundle/**/*
+  - "**/.bundle/**/*"
+  - .ruby-lsp/**/*
+  - "**/.ruby-lsp/**/*"
+require: []
+domains: []
+reporters:
+  - require_not_found
+formatter:
+  rubocop:
+    cops: safe
+    except: []
+    only: []
+    extra_args: []
+type_checker:
+  rules: {}
+require_paths: []
+plugins: []
+max_files: 10000

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@
 !/.config/nvim/lua/rc/pluginconfig/**
 !/.config/nvim/lua/rc/keymaps/**
 
+## solargraph
+!/.config/solargraph
+!/.config/solargraph/**
+
 ## mise
 !/.config/mise/config.toml
 


### PR DESCRIPTION
# 背景

- Ruby ファイルを開いたとき、明示設定していない `rubocop --lsp` が `solargraph` と一緒に起動していました。
- `mason-lspconfig.nvim` の現在版は、インストール済み LSP サーバーをデフォルトで自動 enable します。
- `drwallet-worker` では Mason 側 RuboCop がプロジェクトの RuboCop 拡張を読めず、Ruby LSP が壊れて見える原因になっていました。
- `drwallet-worker` では workspace 内の `_build/actrun` なども Solargraph の対象に入り、`The workspace is too large to index` で index が作られない状態も起きていました。
- LSP ジャンプ系キーで Snacks picker の `No results found for lsp_definition` や Neovim 標準 LSP の `No location found` 通知が出るケースもありました。

# 概要

- `mason-lspconfig.setup()` に `automatic_enable = false` を追加しました。
- この設定では `servers.setup()` 側で明示した LSP だけを起動するため、意図しない RuboCop LSP の attach を防ぎます。
- Solargraph の共通設定を追加し、生成物・依存物・spec/test などを index 対象から外して、大きい Ruby workspace でも app 側の定義を拾いやすくしました。
- `gd`, `gD`, `gr`, `gI`, `gy` は Snacks picker / Neovim 標準の空結果通知経由ではなく、低レベルの LSP request を直接使うようにしました。
- 結果が空のときは通知せず戻り、複数 client が attach していても method 対応 client だけへ request します。
- Solargraph が同じ module の複数定義を返す場合は、カーソル上の constant 名に対応する同名 Ruby ファイルを優先して移動します。

# 関連情報

- Jira issue: なし

# 確認方法

- `stylua --check .config/nvim/lua/rc/lsp/init.lua`
- `stylua --check .config/nvim/lua/rc/keymaps/plugins.lua`
- Ruby ファイルを Neovim headless で開き、`solargraph` のみ attach することを確認
- Lua ファイルを Neovim headless で開き、`lua_ls` が attach することを確認
- 起動後の `gd`, `gD`, `gr`, `gI`, `gy` が標準 LSP コールバックへ割り当たっていることを確認
- `/Users/urugus/dev/drwallet-worker` で `solargraph list` が 1,889 files になり、workspace size 上限で index を諦めないことを確認
- `/Users/urugus/dev/drwallet-worker/app/models/user.rb` を Neovim TUI で実際に開き、Solargraph の workspace mapping が 1,878/1,878 files で 100% 完了することを確認
- `/Users/urugus/dev/drwallet-worker/app/models/user.rb` を現在の Neovim 設定で開き、`gd` mapping 経由で `WorkRole.where` が `/Users/urugus/dev/drwallet-worker/app/models/work_role.rb:20` へ移動することを確認
- 同じ確認で `skip_confirmation!` は Solargraph から空結果が返り、カーソルは `/Users/urugus/dev/drwallet-worker/app/models/user.rb:171` のまま、`No location` / method unsupported / SnacksPicker `lsp_definition` の通知が出ないことを確認
- `/Users/urugus/dev/drwallet-worker/app/commands/invoices/receive_entry_request_command.rb` を現在の Neovim 設定で開き、`gd` mapping 経由で `ClientFeatureReleaseSetting` が `/Users/urugus/dev/drwallet-worker/packs/client_feature_release_setting/app/models/client_feature_release_setting.rb:3` へ移動することを確認
- 同じ確認で `Public.check_enabled` の `Public` が `/Users/urugus/dev/drwallet-worker/packs/client_feature_release_setting/public/client_feature_release_setting.rb:18` へ移動することを確認
- `/Users/urugus/dev/drwallet-worker/app/services/external_output/operator_input_count.rb` を Neovim headless で開き、`CreateInvoiceRows` / `GoogleSheetService` / `output_worksheet` / `sheet_title_by` が定義へ解決されることを確認
- Solargraph の限界として、`skip_confirmation!` / `persisted?` / `ActiveSupport::TimeZone` / 一部 nested constant は未解決のまま残ることを確認
