### PR TITLE
neovim: LSP 設定を整理

### DIFF
--- a/.config/nvim/lua/rc/lsp/capabilities.lua
+++ b/.config/nvim/lua/rc/lsp/capabilities.lua
@@ -1,11 +1,17 @@
 local M = {}
 
+local capabilities
+
 function M.get()
-  return vim.tbl_deep_extend(
-    "force",
-    vim.lsp.protocol.make_client_capabilities(),
-    require("cmp_nvim_lsp").default_capabilities()
-  )
+  if not capabilities then
+    capabilities = vim.tbl_deep_extend(
+      "force",
+      vim.lsp.protocol.make_client_capabilities(),
+      require("cmp_nvim_lsp").default_capabilities()
+    )
+  end
+
+  return vim.deepcopy(capabilities)
 end
 
 return M

--- a/.config/nvim/lua/rc/lsp/diagnostic.lua
+++ b/.config/nvim/lua/rc/lsp/diagnostic.lua
@@ -2,6 +2,19 @@ local M = {}
 
 function M.setup()
   local signs = { Error = "", Warn = "", Hint = "󰛩", Info = "" }
+
+  vim.diagnostic.config({
+    virtual_text = false,
+    float = {
+      border = "rounded",
+      source = "always",
+    },
+    signs = true,
+    underline = true,
+    update_in_insert = false,
+    severity_sort = true,
+  })
+
   for type, icon in pairs(signs) do
     local hl = "DiagnosticSign" .. type
     vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })

--- a/.config/nvim/lua/rc/lsp/init.lua
+++ b/.config/nvim/lua/rc/lsp/init.lua
@@ -32,7 +32,6 @@ function M.setup()
   diagnostic.setup()
   attach.setup_autocmd()
 
-  require("mason").setup()
   require("mason-lspconfig").setup({
     ensure_installed = servers.ensure_installed,
     automatic_enable = false,

--- a/.config/nvim/lua/rc/lsp/servers.lua
+++ b/.config/nvim/lua/rc/lsp/servers.lua
@@ -1,32 +1,26 @@
---[[
-  LSP server configuration for Neovim 0.11+ using the new LSP API.
-
-  This module configures and enables LSP servers using:
-    - vim.lsp.config(): to set up individual server configurations.
-    - vim.lsp.enable(): to enable the specified servers after configuration.
-
-  Implementation approach:
-    * Server-specific settings are defined in `server_configs`.
-    * All servers in `server_configs` (except rust_analyzer) are configured via `vim.lsp.config()`.
-    * rust_analyzer is handled specially, preferring rust-tools if available.
-    * Servers are enabled collectively using `vim.lsp.enable()`.
-]]
-
 local capabilities_mod = require("rc.lsp.capabilities")
 
 local M = {}
 
--- Mason で確実に入れておきたいサーバー
 M.ensure_installed = { "ts_ls", "rust_analyzer", "lua_ls", "terraformls", "pyright", "solargraph" }
 
-local default_servers = { "ts_ls", "terraformls", "pyright" }
-
-local server_configs = {
+local servers = {
+  ts_ls = {},
+  rust_analyzer = {},
+  terraformls = {},
+  pyright = {},
   lua_ls = {
     settings = {
       Lua = {
+        completion = { callSnippet = "Replace" },
         diagnostics = { globals = { "vim" } },
         hint = { enable = true },
+        runtime = { version = "LuaJIT" },
+        telemetry = { enable = false },
+        workspace = {
+          checkThirdParty = false,
+          library = vim.api.nvim_get_runtime_file("", true),
+        },
         format = {
           enable = true,
           defaultConfig = {
@@ -38,8 +32,6 @@ local server_configs = {
     },
   },
   solargraph = {
-    cmd = { "solargraph", "stdio" },
-    filetypes = { "ruby" },
     init_options = {
       formatting = false,
       diagnostics = false,
@@ -59,75 +51,25 @@ local server_configs = {
     },
   },
   hls = {
-    cmd = { "haskell-language-server-wrapper", "--lsp" },
-    filetypes = { "haskell", "lhaskell" },
     settings = {
       haskell = { formattingProvider = "ormolu" },
     },
   },
-  astro = {
-    cmd = { "astro-ls", "--studio" },
-    filetypes = { "astro" },
-  },
-  rust_analyzer = {
-    -- handled separately to prefer rust-tools when available
-  },
+  astro = {},
 }
 
 local function with_cap(capabilities, config)
   return vim.tbl_deep_extend("force", { capabilities = capabilities }, config or {})
 end
 
--- rust_analyzer のセットアップ（rust-tools があればそれを優先）
--- @return boolean rust-tools が使用された場合は true
-local function setup_rust_analyzer(caps)
-  local rust_cfg = with_cap(caps, server_configs.rust_analyzer)
-  local ok, rust_tools = pcall(require, "rust-tools")
-
-  if ok then
-    rust_tools.setup({ server = rust_cfg })
-    return true
-  end
-
-  vim.lsp.config("rust_analyzer", rust_cfg)
-  return false
-end
-
 function M.setup(capabilities)
   local caps = capabilities or capabilities_mod.get()
 
-  -- server_configs にあるものを設定（rust_analyzer以外）
-  for name, cfg in pairs(server_configs) do
-    if name ~= "rust_analyzer" then
-      vim.lsp.config(name, with_cap(caps, cfg))
-    end
+  for name, cfg in pairs(servers) do
+    vim.lsp.config(name, with_cap(caps, cfg))
   end
 
-  -- default_servers で server_configs にないものも設定
-  for _, name in ipairs(default_servers) do
-    if not server_configs[name] then
-      vim.lsp.config(name, with_cap(caps))
-    end
-  end
-
-  -- rust_analyzer セットアップ
-  local rust_tools_enabled = setup_rust_analyzer(caps)
-
-  -- server_configs と default_servers から有効化するサーバーリストを構築
-  -- rust-tools が有効な場合は rust_analyzer を除外
-  local servers_set = {}
-  for name, _ in pairs(server_configs) do
-    if name ~= "rust_analyzer" or not rust_tools_enabled then
-      servers_set[name] = true
-    end
-  end
-  for _, name in ipairs(default_servers) do
-    if name ~= "rust_analyzer" or not rust_tools_enabled then
-      servers_set[name] = true
-    end
-  end
-  local servers_to_enable = vim.tbl_keys(servers_set)
-  vim.lsp.enable(servers_to_enable)
+  vim.lsp.enable(vim.tbl_keys(servers))
 end
 
 return M

--- a/.config/nvim/lua/rc/pluginconfig/tiny-inline-diagnostic.lua
+++ b/.config/nvim/lua/rc/pluginconfig/tiny-inline-diagnostic.lua
@@ -1,17 +1,3 @@
--- 組み込みの診断表示をオフにする
-vim.diagnostic.config({
-  virtual_text = false, -- 標準のvirtual textをオフに
-  -- 他の診断設定はそのまま維持
-  float = {
-    source = "always",
-  },
-  signs = true,
-  underline = true,
-  update_in_insert = false,
-  severity_sort = true,
-})
-
--- tiny-inline-diagnosticの基本設定
 require("tiny-inline-diagnostic").setup({
   signs = {
     left = "",

--- a/.config/nvim/lua/rc/plugins/lsp.lua
+++ b/.config/nvim/lua/rc/plugins/lsp.lua
@@ -77,6 +77,8 @@ return {
   {
     "williamboman/mason-lspconfig.nvim",
     dependencies = {
+      "folke/neoconf.nvim",
+      "hrsh7th/cmp-nvim-lsp",
       "williamboman/mason.nvim",
       "neovim/nvim-lspconfig",
     },


### PR DESCRIPTION
# 背景

- Neovim の LSP 設定に Mason 初期化やサーバー定義の重複があり、設定の見通しが悪くなっていた。
- Neovim 0.11+ の `vim.lsp.config` / `vim.lsp.enable` 前提に寄せて、余分な分岐を減らしたい。

# 概要

- LSP サーバー定義を単一テーブルへ集約し、`rust-tools` 向けの未使用分岐を削除。
- Mason の二重 `setup()` を解消し、LSP 初期化に必要な `neoconf.nvim` / `cmp-nvim-lsp` 依存を明示。
- 診断の共通設定を `tiny-inline-diagnostic` 側から LSP 診断モジュールへ移動。
- `lua_ls` の runtime / workspace / telemetry 設定を補強。
- Astro は lspconfig の標準定義を使う形に戻し、誤った固定コマンド指定を削除。

# 確認方法

- `stylua --check .config/nvim/lua/rc/lsp/init.lua .config/nvim/lua/rc/lsp/servers.lua .config/nvim/lua/rc/lsp/capabilities.lua .config/nvim/lua/rc/lsp/diagnostic.lua .config/nvim/lua/rc/pluginconfig/tiny-inline-diagnostic.lua .config/nvim/lua/rc/plugins/lsp.lua`
- `XDG_DATA_HOME=/private/tmp/nvim-data XDG_CACHE_HOME=/private/tmp/nvim-cache XDG_STATE_HOME=/private/tmp/nvim-state nvim -u NONE --headless -i NONE --cmd 'set runtimepath+=/Users/urugus/.local/share/nvim/lazy/nvim-lspconfig' +'lua package.path = vim.fn.getcwd() .. "/.config/nvim/lua/?.lua;" .. vim.fn.getcwd() .. "/.config/nvim/lua/?/init.lua;" .. package.path; require("rc.lsp.servers").setup(vim.lsp.protocol.make_client_capabilities())' +qa`
- `XDG_DATA_HOME=/private/tmp/nvim-data XDG_CACHE_HOME=/private/tmp/nvim-cache XDG_STATE_HOME=/private/tmp/nvim-state nvim -u NONE --headless -i NONE --cmd 'set runtimepath+=/Users/urugus/.local/share/nvim/lazy/cmp-nvim-lsp' +'lua package.path = vim.fn.getcwd() .. "/.config/nvim/lua/?.lua;" .. vim.fn.getcwd() .. "/.config/nvim/lua/?/init.lua;" .. package.path; require("rc.lsp.diagnostic").setup(); require("rc.lsp.capabilities").get()' +qa`
- `XDG_DATA_HOME=/private/tmp/nvim-data XDG_CACHE_HOME=/private/tmp/nvim-cache XDG_STATE_HOME=/private/tmp/nvim-state nvim --headless -i NONE +qa`

# 補足

- `nvim --headless` は sandbox の都合で `XDG_*` を `/private/tmp` に向けて確認した。
- 作業前から存在していた未コミット変更は、この PR には含めていない。
