### PR TITLE
starship: フォント依存のないプロンプトにする

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,25 +1,20 @@
 format = """
 $directory\
-[](fg:#88C0D0 bg:#394260)\
 $git_branch\
 $git_status\
-[](fg:#394260)\
 $fill\
-[](fg:#212736)\
 $nodejs\
 $rust\
 $ruby\
 $golang\
 $php\
-[](fg:#1d2230 bg:#212736)\
 $time\
-[](fg:#88C0D0 bg:#1d2230)\
 $os\
-[](fg:#88C0D0)\
 \n$character"""
 
 add_newline = true
 command_timeout = 1000
+continuation_prompt = "[.](bright-black) "
 
 # left_promptとright_promptの間を何で埋めるか設定
 [fill]
@@ -31,64 +26,88 @@ style = "fg:#2E3440 bg:#88C0D0 bold"
 disabled = false
 
 [os.symbols]
-Macos = "  " # nf-fa-apple
-Ubuntu = "  " # nf-linux-ubuntu
-Debian = "  " # nf-linux-debian
+Macos = " mac "
+Ubuntu = " ubuntu "
+Debian = " debian "
+Linux = " linux "
+Windows = " windows "
+Unknown = " unknown "
 
 [directory]
 style = "fg:#2E3440 bg:#88C0D0 bold"
 format = "[ $path ]($style)"
 truncation_length = 10
 truncate_to_repo = false
-truncation_symbol = "…/"
+truncation_symbol = ".../"
+read_only = " ro"
 
 [directory.substitutions]
-"Documents" = "󰈙 "
-"Downloads" = " "
-"Music" = " "
-"Pictures" = " "
+"Documents" = "Documents"
+"Downloads" = "Downloads"
+"Music" = "Music"
+"Pictures" = "Pictures"
 
 [gcloud]
 disabled = true
 
 [git_branch]
-symbol = ""
+symbol = "git"
 style = "bg:#394260"
 format = '[[ $symbol $branch ](fg:#769ff0 bg:#394260)]($style)'
+truncation_symbol = "..."
 
 [git_status]
 style = "bg:#394260"
 format = '[[($all_status$ahead_behind )](fg:#769ff0 bg:#394260)]($style)'
-ahead = '⇡${count}'
-diverged = '⇕⇡${ahead_count}⇣${behind_count}'
-behind = '⇣${count}'
-staged = '[++\($count\)](fg: #0abf53, bg: #394260)'
+ahead = 'ahead:${count}'
+behind = 'behind:${count}'
+diverged = 'ahead:${ahead_count} behind:${behind_count}'
+up_to_date = ''
+conflicted = 'conflict:${count} '
+stashed = 'stash:${count} '
+modified = 'mod:${count} '
+staged = 'staged:${count} '
+renamed = 'renamed:${count} '
+deleted = 'del:${count} '
 # libgit2 (used by starship) reports phantom untracked entries due to differences
 # in .gitignore handling vs git CLI; suppress the noisy `?` symbol.
 untracked = ''
 
 [nodejs]
-symbol = ""
+symbol = "node"
 style = "bg:#212736"
 format = '[[ $symbol ($version) ](fg:#68A063 bg:#212736)]($style)'
 
 [rust]
-symbol = ""
+symbol = "rust"
 style = "bg:#212736"
 format = '[[ $symbol ($version) ](fg:#B7410E bg:#212736)]($style)'
 
 [ruby]
-symbol = ""
+symbol = "ruby"
 style = "bg:#212736"
 format = '[[ $symbol ($version) ](fg:#cc0000 bg:#212736)]($style)'
 
 [golang]
-symbol = ""
+symbol = "go"
 style = "bg:#212736"
 format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[php]
+symbol = "php"
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#8892BF bg:#212736)]($style)'
 
 [time]
 disabled = false
 time_format = "%R" # Hour:Minute Format
 style = "bg:#1d2230"
-format = '[[  $time ](fg:#a0a9cb bg:#1d2230)]($style)'
+format = '[[ time $time ](fg:#a0a9cb bg:#1d2230)]($style)'
+
+[character]
+success_symbol = "[>](bold green)"
+error_symbol = "[x](bold red)"
+vimcmd_symbol = "[<](bold green)"
+vimcmd_visual_symbol = "[v](bold yellow)"
+vimcmd_replace_symbol = "[r](bold purple)"
+vimcmd_replace_one_symbol = "[r](bold purple)"


### PR DESCRIPTION
# 背景

- Codex 内蔵ターミナルなど、Nerd Font / Powerline グリフを描画できない環境で starship のアイコンが四角く表示される。
- フォント変更ではなく、starship 側をどのターミナルでも表示しやすい構成にする。

# 概要

- starship の Powerline 区切り文字と Nerd Font アイコンを ASCII 表記に置き換え。
- 既存の背景色・文字色・左右配置は維持し、背景ブロックがそのまま並ぶデザインに変更。
- OS、Git、言語ランタイム、時刻、vi mode prompt、continuation prompt の表示をフォント依存しない文字に変更。

# 確認方法

- `starship print-config`
- `env STARSHIP_CACHE=/private/tmp/starship-cache TERM=xterm-256color starship prompt`
