### PR TITLE
neovim: fix solargraph root detection

### DIFF
--- a/.config/nvim/lua/rc/lsp/servers.lua
+++ b/.config/nvim/lua/rc/lsp/servers.lua
@@ -4,6 +4,20 @@ local M = {}
 
 M.ensure_installed = { "ts_ls", "rust_analyzer", "lua_ls", "terraformls", "pyright", "solargraph" }
 
+local function solargraph_root_dir(bufnr, on_dir)
+  local root = vim.fs.root(bufnr, { ".solargraph.yml", "Gemfile", ".git" })
+  if not root then
+    return
+  end
+
+  -- ~/Gemfile を拾ってホーム全体を Ruby workspace にしない。
+  if root == vim.uv.os_homedir() then
+    return
+  end
+
+  on_dir(root)
+end
+
 local servers = {
   ts_ls = {},
   rust_analyzer = {},
@@ -32,6 +46,7 @@ local servers = {
     },
   },
   solargraph = {
+    root_dir = solargraph_root_dir,
     init_options = {
       formatting = false,
       diagnostics = false,

--- a/.config/nvim/lua/rc/lsp/servers.lua
+++ b/.config/nvim/lua/rc/lsp/servers.lua
@@ -5,7 +5,7 @@ local M = {}
 M.ensure_installed = { "ts_ls", "rust_analyzer", "lua_ls", "terraformls", "pyright", "solargraph" }
 
 local function solargraph_root_dir(bufnr, on_dir)
-  local root = vim.fs.root(bufnr, { ".solargraph.yml", "Gemfile", ".git" })
+  local root = vim.fs.root(bufnr, { { ".solargraph.yml", "Gemfile", ".git" } })
   if not root then
     return
   end


### PR DESCRIPTION
# 背景

- Ruby ファイルで Solargraph の定義ジャンプが効かないケースを調査したところ、ホーム直下の `Gemfile` により `/Users/urugus` 全体が Ruby workspace として扱われる可能性がありました。
- その場合、`Desktop` など本来対象外の場所まで Solargraph が探索し、権限エラーや重い初期化につながります。

# 概要

- Solargraph の root 判定をカスタム関数に変更しました。
- `.solargraph.yml`, `Gemfile`, `.git` を root marker として使いつつ、検出 root がホームディレクトリそのものの場合は Solargraph を起動しないようにしました。

# 確認方法

- `stylua --check .config/nvim/lua/rc/lsp/servers.lua`
- `nvim --headless /Users/urugus/dev/drwallet-worker/app/services/external_output/operator_input_count_by_bpo.rb ...` で Solargraph が対象リポジトリ root で起動することを確認
- `nvim --headless /Users/urugus/Gemfile ...` でホーム直下の `Gemfile` では Solargraph が起動しないことを確認
