### PR TITLE
neovim: prefer homebrew solargraph

### DIFF
--- a/.config/nvim/lua/rc/lsp/servers.lua
+++ b/.config/nvim/lua/rc/lsp/servers.lua
@@ -18,6 +18,17 @@ local function solargraph_root_dir(bufnr, on_dir)
   on_dir(root)
 end
 
+local function solargraph_cmd()
+  -- Prefer Homebrew because Mason 0.59.2 can hang while mapping workspaces.
+  for _, path in ipairs({ "/opt/homebrew/bin/solargraph", "/usr/local/bin/solargraph" }) do
+    if vim.fn.executable(path) == 1 then
+      return { path, "stdio" }
+    end
+  end
+
+  return { "solargraph", "stdio" }
+end
+
 local servers = {
   ts_ls = {},
   rust_analyzer = {},
@@ -46,6 +57,7 @@ local servers = {
     },
   },
   solargraph = {
+    cmd = solargraph_cmd(),
     root_dir = solargraph_root_dir,
     init_options = {
       formatting = false,


### PR DESCRIPTION
# 背景

- Mason 版 Solargraph 0.59.2 が workspace mapping 中に `can't add a new key into hash during iteration` で停止し、Neovim 上で mapping が 90% 付近から進まなくなることがある。
- Homebrew 版 Solargraph 0.58.3 では同じ例外が出ていないため、Neovim からは Homebrew 版を優先して起動する。

# 概要

- `solargraph` の LSP 起動コマンドを明示し、macOS の Homebrew パスを優先するように変更。
- Homebrew 版が見つからない環境では従来どおり `solargraph` を PATH から解決する。

# 確認方法

- `stylua --check .config/nvim/lua/rc/lsp/servers.lua`
- `/opt/homebrew/bin/solargraph --version`
- `/Users/urugus/.local/share/nvim/mason/bin/solargraph --version`
- Neovim の LSP ログで、変更後の起動が `/opt/homebrew/bin/solargraph` になっていることを確認。
