### PR TITLE
zsh: Android SDK (adb/emulator) を PATH に追加

### DIFF
--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -96,7 +96,14 @@ export PATH="$HOME/.npm-global/bin:$PATH"
 
 # Android SDK (adb / emulator / sdkmanager)
 # Re-assert here because interactive plugin loading (zinit) drops the path
-# entries set in .zshenv; ANDROID_HOME is exported from .zshenv.
-if [ -n "$ANDROID_HOME" ]; then
-  export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
+# entries set in .zshenv.
+if [ -n "${ANDROID_HOME:-}" ]; then
+  typeset -U path PATH
+  path=(
+    $ANDROID_HOME/platform-tools(N-/)
+    $ANDROID_HOME/emulator(N-/)
+    $ANDROID_HOME/cmdline-tools/latest/bin(N-/)
+    $path
+  )
+  export PATH
 fi

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -93,3 +93,10 @@ if [ -x "$HOME/.codex/hooks/codex-with-sb-session.sh" ]; then
   }
 fi
 export PATH="$HOME/.npm-global/bin:$PATH"
+
+# Android SDK (adb / emulator / sdkmanager)
+# Re-assert here because interactive plugin loading (zinit) drops the path
+# entries set in .zshenv; ANDROID_HOME is exported from .zshenv.
+if [ -n "$ANDROID_HOME" ]; then
+  export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
+fi

--- a/.zshenv
+++ b/.zshenv
@@ -34,10 +34,6 @@ export EDITOR="nvim"
 # AI
 # export CLAUDE_CODE_USE_BEDROCK=1
 
-# Android SDK (adb / emulator / sdkmanager)
-export ANDROID_HOME="$HOME/Library/Android/sdk"
-export ANDROID_SDK_ROOT="$ANDROID_HOME"
-
 typeset -U path PATH manpath sudo_path
 
 # paths
@@ -58,9 +54,6 @@ path=(
   $HOME/.yarn/bin(N-/)
   $HOME/.config/yarn/global/node_modules/.bin(N-/)
   $HOME/.deno/bin(N-/)
-  $ANDROID_HOME/platform-tools(N-/)
-  $ANDROID_HOME/emulator(N-/)
-  $ANDROID_HOME/cmdline-tools/latest/bin(N-/)
   $path
 )
 
@@ -73,3 +66,20 @@ setopt no_global_rcs
 
 # Load local secrets (not tracked by git)
 [[ -f "$HOME/.zshenv.local" ]] && source "$HOME/.zshenv.local"
+
+# Android SDK (adb / emulator / sdkmanager)
+if [ -z "${ANDROID_HOME:-}" ] && [ -d "$HOME/Library/Android/sdk" ]; then
+  export ANDROID_HOME="$HOME/Library/Android/sdk"
+fi
+
+if [ -n "${ANDROID_HOME:-}" ]; then
+  export ANDROID_HOME
+  export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
+  path=(
+    $ANDROID_HOME/platform-tools(N-/)
+    $ANDROID_HOME/emulator(N-/)
+    $ANDROID_HOME/cmdline-tools/latest/bin(N-/)
+    $path
+  )
+  export PATH
+fi

--- a/.zshenv
+++ b/.zshenv
@@ -34,6 +34,10 @@ export EDITOR="nvim"
 # AI
 # export CLAUDE_CODE_USE_BEDROCK=1
 
+# Android SDK (adb / emulator / sdkmanager)
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+
 typeset -U path PATH manpath sudo_path
 
 # paths
@@ -54,6 +58,9 @@ path=(
   $HOME/.yarn/bin(N-/)
   $HOME/.config/yarn/global/node_modules/.bin(N-/)
   $HOME/.deno/bin(N-/)
+  $ANDROID_HOME/platform-tools(N-/)
+  $ANDROID_HOME/emulator(N-/)
+  $ANDROID_HOME/cmdline-tools/latest/bin(N-/)
   $path
 )
 


### PR DESCRIPTION
## 概要
Android SDK 同梱の `adb` / `emulator` / `sdkmanager`（`~/Library/Android/sdk`）を PATH から使えるようにする。SDK は既に存在するため新規インストールはなし、設定のみ。

## 変更
- `.zshenv`: `ANDROID_HOME` / `ANDROID_SDK_ROOT` を export し、`path` 配列に `platform-tools` / `emulator` / `cmdline-tools/latest/bin` を追加（非インタラクティブシェル用）
- `.config/zsh/.zshrc` 末尾: 同じ PATH を再 export。インタラクティブシェルでは zinit のプラグインロードが `.zshenv` の `path` 追記を落とすため、生き残る経路（既存の npm-global と同様）で再アサート

## 確認
- `zsh -lic 'command -v adb'` → `~/Library/Android/sdk/platform-tools/adb`（v1.0.41）解決
- `ANDROID_HOME` がインタラクティブシェルで設定済み
- `adb devices` 実行可（接続端末なしの空リスト）

## 備考
- エミュレータをローカルで起動する場合は別途 `sdkmanager` で `emulator` パッケージとシステムイメージ（Apple Silicon なら arm64 推奨）＋ AVD 作成が必要（本PMの範囲外）