### PR TITLE
neovim: stop managing solargraph via Mason (fix gd install error)

### DIFF
--- a/.config/nvim/lua/rc/lsp/servers.lua
+++ b/.config/nvim/lua/rc/lsp/servers.lua
@@ -2,7 +2,10 @@ local capabilities_mod = require("rc.lsp.capabilities")
 
 local M = {}
 
-M.ensure_installed = { "ts_ls", "rust_analyzer", "lua_ls", "terraformls", "pyright", "solargraph" }
+-- solargraph is intentionally NOT Mason-managed: on macOS it comes from Homebrew
+-- (see solargraph_cmd); Mason's install is fragile here. On Linux install it via
+-- the system (e.g. `gem install solargraph`) so it is on PATH.
+M.ensure_installed = { "ts_ls", "rust_analyzer", "lua_ls", "terraformls", "pyright" }
 
 local function solargraph_root_dir(bufnr, on_dir)
   local root = vim.fs.root(bufnr, { { ".solargraph.yml", "Gemfile", ".git" } })


### PR DESCRIPTION
# 背景

PR #71 のレビュー対応で `ensure_installed` に `solargraph` を戻したところ、このマシンでは Mason の solargraph インストールが失敗し、`gd` 実行時に毎回 `[mason-lspconfig.nvim] failed to install solargraph` が出るようになっていた。

失敗原因は `mason/share/mason-schemas/lsp/solargraph.json` の dangling symlink による `already linked` エラー（#71 時の手動クリーンアップの消し残り）。そもそもこのマシンでは solargraph は Homebrew で提供しており、Mason 管理は不要かつ不安定。

# 概要

- `ensure_installed` から `solargraph` を除外し、Mason 管理をやめる（意図をコメントで明記）
- 方針: macOS は Homebrew（`solargraph_cmd`）、Linux は system の `gem install solargraph` で PATH 上の solargraph を使う
- ローカル環境に残っていた Mason の dangling symlink も別途削除済み

# 関連情報

- Follow-up of #71
