### PR TITLE
neovim: 壊れた設定と非推奨APIを修正

### DIFF
--- a/.config/nvim/lua/rc/autocmd.lua
+++ b/.config/nvim/lua/rc/autocmd.lua
@@ -95,7 +95,7 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, {
     local function auto_mkdir(dir, force)
       if
         vim.fn.empty(dir) == 1
-        or string.match(dir, "^%w+://")
+        or string.match(dir, "^%a[%w%+%-%.]*://") -- RFC 3986 の scheme (git+ssh:// 等を含む)
         or vim.fn.isdirectory(dir) == 1
         or string.match(dir, "^suda:")
       then

--- a/.config/nvim/lua/rc/autocmd.lua
+++ b/.config/nvim/lua/rc/autocmd.lua
@@ -81,7 +81,7 @@ vim.api.nvim_create_autocmd({ "TextYankPost" }, {
   group = group_name,
   pattern = "*",
   callback = function()
-    vim.highlight.on_yank({
+    vim.hl.on_yank({
       higroup = (vim.fn.hlexists("HighlightedyankRegion") > 0 and "HighlightedyankRegion" or "Visual"),
       timeout = 200,
     })
@@ -95,7 +95,7 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, {
     local function auto_mkdir(dir, force)
       if
         vim.fn.empty(dir) == 1
-        or string.match(dir, "^%w%+://")
+        or string.match(dir, "^%w+://")
         or vim.fn.isdirectory(dir) == 1
         or string.match(dir, "^suda:")
       then
@@ -104,11 +104,11 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, {
       if not force then
         vim.fn.inputsave()
         local result = vim.fn.input(string.format('"%s" does not exist. Create? [y/N]', dir), "")
+        vim.fn.inputrestore()
         if vim.fn.empty(result) == 1 then
           print("Canceled")
           return
         end
-        vim.fn.inputrestore()
       end
       vim.fn.mkdir(dir, "p")
     end

--- a/.config/nvim/lua/rc/display.lua
+++ b/.config/nvim/lua/rc/display.lua
@@ -1,6 +1,4 @@
--- nvim color
-vim.env.NVIM_TUI_ENABLE_TRUE_COLOR = 1
-
+-- nvim color (true color は option.lua の termguicolors)
 vim.o.synmaxcol = 200
 -- ColorScheme
 vim.cmd.syntax("enable")
@@ -29,7 +27,7 @@ vim.o.pumheight = 10 -- 補完候補の表示数
 vim.o.foldmethod = "manual"
 vim.o.foldlevel = 1
 vim.o.foldlevelstart = 99
-vim.w.foldcolumn = "0:"
+-- foldcolumn は pluginconfig/nvim-ufo.lua で設定する
 
 -- font
 vim.o.guifont = "UDEV Gothic LG,Hack Nerd Font,Fira Code"

--- a/.config/nvim/lua/rc/editor.lua
+++ b/.config/nvim/lua/rc/editor.lua
@@ -2,7 +2,7 @@
 -- Editor Configuration
 -- ===============================
 -- neovide
-if vim.fn.exists("g:neovide") then
+if vim.g.neovide then
   vim.g.neovide_cursor_animation_length = 0.13
   vim.g.neovide_remember_window_size = true
   vim.g.neovide_opacity = 0.7

--- a/.config/nvim/lua/rc/init.lua
+++ b/.config/nvim/lua/rc/init.lua
@@ -1,13 +1,6 @@
 local M = {}
 
 local function load_local_configs()
-  -- Vimscript plugin fragments under rc/myplugins/*.vim
-  vim.cmd([[
-for f in split(glob('~/.config/nvim/rc/myplugins/*.vim'), '\n')
-  execute 'source ' . f
-endfor
-]])
-
   -- Optional Lua add-ons under rc/myplugins/opt/*.lua (lazy-loaded)
   vim.schedule(function()
     local opt_dir = vim.fn.stdpath("config") .. "/lua/rc/myplugins/opt"

--- a/.config/nvim/lua/rc/lsp/diagnostic.lua
+++ b/.config/nvim/lua/rc/lsp/diagnostic.lua
@@ -3,10 +3,10 @@ local M = {}
 function M.setup()
   local severity = vim.diagnostic.severity
   local icons = {
-    [severity.ERROR] = "",
-    [severity.WARN] = "",
+    [severity.ERROR] = "󰅚",
+    [severity.WARN] = "󰀪",
     [severity.HINT] = "󰛩",
-    [severity.INFO] = "",
+    [severity.INFO] = "󰋽",
   }
 
   vim.diagnostic.config({

--- a/.config/nvim/lua/rc/lsp/diagnostic.lua
+++ b/.config/nvim/lua/rc/lsp/diagnostic.lua
@@ -1,24 +1,33 @@
 local M = {}
 
 function M.setup()
-  local signs = { Error = "", Warn = "", Hint = "󰛩", Info = "" }
+  local severity = vim.diagnostic.severity
+  local icons = {
+    [severity.ERROR] = "",
+    [severity.WARN] = "",
+    [severity.HINT] = "󰛩",
+    [severity.INFO] = "",
+  }
 
   vim.diagnostic.config({
     virtual_text = false,
     float = {
       border = "rounded",
-      source = "always",
+      source = true,
     },
-    signs = true,
+    signs = {
+      text = icons,
+      numhl = {
+        [severity.ERROR] = "DiagnosticSignError",
+        [severity.WARN] = "DiagnosticSignWarn",
+        [severity.HINT] = "DiagnosticSignHint",
+        [severity.INFO] = "DiagnosticSignInfo",
+      },
+    },
     underline = true,
     update_in_insert = false,
     severity_sort = true,
   })
-
-  for type, icon in pairs(signs) do
-    local hl = "DiagnosticSign" .. type
-    vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
-  end
 end
 
 return M

--- a/.config/nvim/lua/rc/lsp/init.lua
+++ b/.config/nvim/lua/rc/lsp/init.lua
@@ -7,7 +7,7 @@ local M = {}
 
 local function ensure_state_home()
   -- Mason は stdpath("state") を利用する。書き込み不可な場合は一時ディレクトリへ退避。
-  local ok = vim.loop.fs_access(vim.fn.stdpath("state"), "W")
+  local ok = vim.uv.fs_access(vim.fn.stdpath("state"), "W")
   if not ok then
     local fallback = vim.fn.stdpath("data") .. "/mason-state"
     vim.fn.mkdir(fallback, "p")

--- a/.config/nvim/lua/rc/option.lua
+++ b/.config/nvim/lua/rc/option.lua
@@ -4,7 +4,6 @@ vim.g.maplocalleader = "\\"
 vim.o.termguicolors = true
 vim.o.shada = "'50,<1000,s100,\"1000,!" -- YankRing用に!を追加
 vim.o.shadafile = vim.fn.stdpath("data") .. "/shada/main.shada"
-vim.fn.mkdir(vim.fn.fnamemodify(vim.fn.expand(vim.g.viminfofile), ":h"), "p")
 -- vim.o.lazyredraw   vim-anzuの検索結果が見えなくなることがあるためOFF
 vim.o.complete = vim.o.complete .. ",k" -- 補完に辞書ファイル追加
 vim.o.completeopt = "menuone,noselect,noinsert"

--- a/.config/nvim/lua/rc/pluginconfig/lspsaga.lua
+++ b/.config/nvim/lua/rc/pluginconfig/lspsaga.lua
@@ -1,17 +1,2 @@
-local lspsaga = require("lspsaga")
-lspsaga.setup({ -- defaults ...
-  -- use emoji lightbulb in default
-  code_action_icon = "󱧡",
-  -- custom finder title winbar function type
-  -- param is current word with symbol icon string type
-  -- return a winbar format string like `%#CustomFinder#Test%*`
-  finder_action_keys = {
-    open = "o",
-    vsplit = "s",
-    split = "i",
-    table = "t",
-    quit = "q",
-    scroll_down = "<C-f>",
-    scroll_up = "<C-b>", -- quit can be a table
-  },
-})
+-- v0.3 で code_action_icon / finder_action_keys は廃止されたためデフォルトで運用する
+require("lspsaga").setup({})

--- a/.config/nvim/lua/rc/pluginconfig/neo-tree.lua
+++ b/.config/nvim/lua/rc/pluginconfig/neo-tree.lua
@@ -62,8 +62,8 @@ require("neo-tree").setup({
         --"thumbs.db"
       },
     },
-    follow_current_file = true, -- This will find and focus the file in the active buffer every
-    -- time the current file is changed while the tree is open.
+    -- 開いているファイルを自動で追従する (v3 はテーブル指定)
+    follow_current_file = { enabled = true },
     use_libuv_file_watcher = false, -- This will use the OS level file watchers
     -- to detect changes instead of relying on nvim autocmd events.
     hijack_netrw_behavior = "open_default", -- netrw disabled, opening a directory opens neo-tree

--- a/.config/nvim/lua/rc/pluginconfig/nvim-cmp.lua
+++ b/.config/nvim/lua/rc/pluginconfig/nvim-cmp.lua
@@ -1,5 +1,3 @@
-vim.g.completeopt = "menu,menuone,noselect"
-
 local cmp = require("cmp")
 local types = require("cmp.types")
 local luasnip = require("luasnip")

--- a/.config/nvim/lua/rc/pluginconfig/toggleterm.lua
+++ b/.config/nvim/lua/rc/pluginconfig/toggleterm.lua
@@ -7,7 +7,7 @@ require("toggleterm").setup({
       return vim.o.columns * 0.5
     end
   end,
-  open_mapping = [[<tt>]],
+  -- 開閉のキーマップは rc/keymaps/plugins.lua の tt/tv/tf/tb で定義している
   hide_numbers = true, -- hide the number column in toggleterm buffers
   shade_filetypes = {},
   shade_terminals = true,

--- a/.config/nvim/lua/rc/pluginconfig/trouble.lua
+++ b/.config/nvim/lua/rc/pluginconfig/trouble.lua
@@ -1,53 +1,8 @@
-require("trouble").setup({
-  position = "bottom", -- position of the list can be: bottom, top, left, right
-  height = 10, -- height of the trouble list when position is top or bottom
-  width = 50, -- width of the list when position is left or right
-  mode = "workspace_diagnostics", -- "workspace_diagnostics", "document_diagnostics", "quickfix", "lsp_references", "loclist"
-  fold_open = "", -- icon used for open folds
-  fold_closed = "", -- icon used for closed folds
-  group = true, -- group results by file
-  padding = true, -- add an extra new line on top of the list
-  action_keys = { -- key mappings for actions in the trouble list
-    -- map to {} to remove a mapping, for example:
-    -- close = {},
-    close = "q", -- close the list
-    cancel = "<esc>", -- cancel the preview and get back to your last window / buffer / cursor
-    refresh = "r", -- manually refresh
-    jump = { "<cr>", "<tab>" }, -- jump to the diagnostic or open / close folds
-    open_split = { "<c-x>" }, -- open buffer in new split
-    open_vsplit = { "<c-v>" }, -- open buffer in new vsplit
-    open_tab = { "<c-t>" }, -- open buffer in new tab
-    jump_close = { "o" }, -- jump to the diagnostic and close the list
-    toggle_mode = "m", -- toggle between "workspace" and "document" diagnostics mode
-    toggle_preview = "P", -- toggle auto_preview
-    hover = "K", -- opens a small popup with the full multiline message
-    preview = "p", -- preview the diagnostic location
-    close_folds = { "zM", "zm" }, -- close all folds
-    open_folds = { "zR", "zr" }, -- open all folds
-    toggle_fold = { "zA", "za" }, -- toggle fold of current file
-    previous = "k", -- preview item
-    next = "j", -- next item
-  },
-  indent_lines = true, -- add an indent guide below the fold icons
-  auto_open = false, -- automatically open the list when you have diagnostics
-  auto_close = false, -- automatically close the list when you have no diagnostics
-  auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
-  auto_fold = false, -- automatically fold a file trouble list at creation
-  auto_jump = { "lsp_definitions" }, -- for the given modes, automatically jump if there is only a single result
-  icons = {
-    -- icons / text used for a diagnostic
-    error = "",
-    warning = "",
-    hint = "󰛩",
-    information = "",
-    other = "󰘥",
-  },
-  use_diagnostic_signs = true, -- enabling this will use the signs defined in your lsp client
-})
+-- v3 のデフォルトで運用する。診断アイコンは rc/lsp/diagnostic.lua の vim.diagnostic.config 由来。
+require("trouble").setup({})
 
-vim.api.nvim_set_keymap("n", "[_Lsp]xx", "<cmd>Trouble<cr>", { silent = true, noremap = true })
-vim.api.nvim_set_keymap("n", "[_Lsp]xw", "<cmd>Trouble workspace_diagnostics<cr>", { silent = true, noremap = true })
-vim.api.nvim_set_keymap("n", "[_Lsp]xd", "<cmd>Trouble document_diagnostics<cr>", { silent = true, noremap = true })
-vim.api.nvim_set_keymap("n", "[_Lsp]xl", "<cmd>Trouble loclist<cr>", { silent = true, noremap = true })
-vim.api.nvim_set_keymap("n", "[_Lsp]xq", "<cmd>Trouble quickfix<cr>", { silent = true, noremap = true })
--- vim.api.nvim_set_keymap("n", "gR", "<cmd>Trouble lsp_references<cr>", { silent = true, noremap = true })
+local opts = { silent = true, noremap = true }
+vim.keymap.set("n", "[_Lsp]xx", "<Cmd>Trouble diagnostics toggle<CR>", opts)
+vim.keymap.set("n", "[_Lsp]xd", "<Cmd>Trouble diagnostics toggle filter.buf=0<CR>", opts)
+vim.keymap.set("n", "[_Lsp]xl", "<Cmd>Trouble loclist toggle<CR>", opts)
+vim.keymap.set("n", "[_Lsp]xq", "<Cmd>Trouble qflist toggle<CR>", opts)

--- a/.config/nvim/lua/rc/plugins/lsp.lua
+++ b/.config/nvim/lua/rc/plugins/lsp.lua
@@ -103,10 +103,7 @@ return {
   -- LSP UI
   {
     "nvimdev/lspsaga.nvim",
-    cmd = {
-      "Lspsaga",
-      "LSoutlineToggle",
-    },
+    cmd = "Lspsaga",
     config = conf("rc/pluginconfig/lspsaga"),
   },
   {

--- a/.config/nvim/lua/rc/plugins/ui.lua
+++ b/.config/nvim/lua/rc/plugins/ui.lua
@@ -47,7 +47,11 @@ return {
   {
     "norcalli/nvim-colorizer.lua",
     event = "VeryLazy",
-    config = true,
+    -- setup() は引数を省略した時だけ全ファイルタイプ (FileType *) に登録する。
+    -- config = true だと空テーブルが渡り、どこにも登録されず無効化される。
+    config = function()
+      require("colorizer").setup()
+    end,
   },
   {
     "folke/todo-comments.nvim",

--- a/.config/nvim/lua/rc/plugins/ui.lua
+++ b/.config/nvim/lua/rc/plugins/ui.lua
@@ -19,6 +19,7 @@ return {
   {
     "folke/snacks.nvim",
     lazy = false,
+    priority = 1000,
     config = conf("rc/pluginconfig/snacks"),
   },
 
@@ -46,21 +47,7 @@ return {
   {
     "norcalli/nvim-colorizer.lua",
     event = "VeryLazy",
-    config = function()
-      local tbl_flatten = vim.tbl_flatten
-      vim.tbl_flatten = function(t)
-        return vim.iter(t):flatten(math.huge):totable()
-      end
-
-      local ok, err = pcall(function()
-        require("colorizer").setup()
-      end)
-
-      vim.tbl_flatten = tbl_flatten
-      if not ok then
-        error(err)
-      end
-    end,
+    config = true,
   },
   {
     "folke/todo-comments.nvim",


### PR DESCRIPTION
# 背景

Neovim 設定のリファクタリングを4本の PR に分けて進める、その1本目。

設定を棚卸ししたところ、**壊れているのに気付かれていない箇所**がまとまって見つかった。診断アイコンが表示されない、キーを押すとエラーになる、コードが完全に空回りしている、といったもの。加えて nvim 0.13 で削除される API を使っている箇所がある。

この PR は挙動が壊れている箇所の修正だけに絞り、構造の変更は一切していない（後続 PR で対応）。

# 概要

## 実害のあったバグ

| ファイル | 内容 |
|---|---|
| `lsp/diagnostic.lua` | `vim.fn.sign_define` は 0.11+ の `vim.diagnostic.config` から参照されず、指定したアイコンが無視されて gutter に `E`/`W`/`I`/`H` が出ていた。`signs.text` / `numhl` へ移行。`float.source` の `"always"` も 0.10 以降は未定義値なので `true` へ |
| `pluginconfig/toggleterm.lua` | `open_mapping = [[<tt>]]` は不正なキー記法。リテラル4文字 `<`,`t`,`t`,`>` が n/i/t にマップされ、normal の `<`（インデント演算子）が曖昧になっていた。実際の割当は `keymaps/plugins.lua` の `tt`/`tv`/`tf`/`tb` にあるので削除 |
| `autocmd.lua` | `auto_mkdir` の URL スキーム判定 `"^%w%+://"` が Lua パターンとして誤り（`%+` は「リテラルの `+`」の意味）。除外が効かず `scp://host/` のようなパスを `mkdir` しにいっていた |
| `autocmd.lua` | `auto_mkdir` のキャンセル経路が `inputrestore()` の前に `return` しており、入力状態がリークしていた |

## 存在しないサブコマンドを叩いていたキーマップ

```mermaid
flowchart LR
    A["[_Lsp]xw<br/>Trouble workspace_diagnostics"] -->|v3 で廃止| B["Trouble diagnostics"]
    C["[_Lsp]xd<br/>Trouble document_diagnostics"] -->|v3 で廃止| D["Trouble diagnostics<br/>filter.buf=0"]
    E["[_Lsp]xq<br/>Trouble quickfix"] -->|v3 で廃止| F["Trouble qflist"]
```

- **Trouble** は v3 が入っているのに設定・キーマップが v2 のまま。`setup()` の `position` / `height` / `action_keys` / `fold_open` / `auto_open` も全て v2 スキーマで無視されるため、v3 のデフォルトに寄せた。`[_Lsp]xw` は修正すると `[_Lsp]xx` と同一になるため削除
- **lspsaga** の `code_action_icon` / `finder_action_keys` は v0.2 時代のキーで、インストール済みの v0.3.1 では無視される。spec の `cmd` からも、v0.3 に存在しない `LSoutlineToggle` を削除

## 非推奨 API

- `vim.highlight.on_yank` → `vim.hl.on_yank`
- `vim.loop.fs_access` → `vim.uv.fs_access`（同じ `lsp/init.lua` 内で `vim.uv.fs_stat` と混在していた）

## no-op / 死んだコード

| 箇所 | なぜ無意味だったか |
|---|---|
| `option.lua` の `vim.g.viminfofile` | `viminfofile` はオプションであって `g:` 変数ではない。`expand(nil)` → `"v:null"` → `":h"` → `"."` となり、実質 `mkdir(".")` を実行していた |
| `display.lua` の `vim.w.foldcolumn = "0:"` | オプションではなく `w:` 変数を書いていた。値 `"0:"` 自体も `foldcolumn` として不正。`foldcolumn` は `pluginconfig/nvim-ufo.lua` が設定している |
| `display.lua` の `NVIM_TUI_ENABLE_TRUE_COLOR` | nvim 0.1.5 で廃止。実際に効いているのは `option.lua` の `termguicolors` |
| `nvim-cmp.lua` の `vim.g.completeopt` | オプションではなくグローバル変数。本物は `option.lua` の `vim.o.completeopt` |
| `init.lua` の `rc/myplugins/*.vim` glob | `rc/` 配下には `pluginconfig/` しかなく、ループが一度も回らない |
| `editor.lua` の `vim.fn.exists("g:neovide")` | `exists()` は 0/1 を返し、Lua では **0 も真**。TUI でも neovide 設定が毎回実行されていた（`vim.g.neovide` による判定に修正） |

## その他

- `plugins/ui.lua` の colorizer 用 `vim.tbl_flatten` モンキーパッチを削除。0.12 では `tbl_flatten` がまだ存在するので不要な上、colorizer 側の呼び出しが遅延クロージャ内にあるためパッチ窓が外れており**そもそも効いていなかった**
- snacks に `priority = 1000` を追加（`:checkhealth lazy` の警告）
- neo-tree の `follow_current_file` を v3 のテーブル形式 `{ enabled = true }` へ

# 動作確認

```bash
stylua --check .config/nvim   # 差分なし
nvim --headless +qa           # exit 0, 出力なし
```

手動確認:
- Lua ファイルを開き、診断の gutter が `E` ではなくアイコンで表示されること
- `[_Lsp]xx` / `[_Lsp]xd` / `[_Lsp]xl` / `[_Lsp]xq` が `E492` を出さずに Trouble を開くこと
- toggleterm が `tt` / `tv` / `tf` / `tb` で開閉すること、normal の `<` が引っかからないこと
- neo-tree がカレントファイルを追従すること

# 補足

`lua/rc/keymaps/` 配下にも同種の修正対象（`client:supports_method`、`vim.diagnostic.jump`、Lspsaga の残りのサブコマンド、`vim.lsp.util.show_document`）があるが、次の PR がキーマップの再編そのものなので、そちらにまとめる。
