### PR TITLE
zsh: terminal-browser のエイリアスとキーバインドを追加

### DIFF
--- a/.config/zsh/rc/alias.zsh
+++ b/.config/zsh/rc/alias.zsh
@@ -38,6 +38,9 @@ alias vi='nvim'
 # zellij
 alias zj='zellij'
 
+# terminal-browser
+alias tb='terminal-browser'
+
 # AI
 alias claude-bedrock='AWS_PROFILE=bedrock claude'
 

--- a/.config/zsh/rc/bindkey.zsh
+++ b/.config/zsh/rc/bindkey.zsh
@@ -47,6 +47,14 @@ function _zellij-widget() {
 zle -N _zellij-widget
 bindkey '^[z' _zellij-widget
 
+## terminal-browser ##
+function _terminal-browser-widget() {
+  BUFFER="terminal-browser open"
+  zle accept-line
+}
+zle -N _terminal-browser-widget
+bindkey '^x^t' _terminal-browser-widget
+
 ## Git ##
 function _lazygit-widget() { lazygit }
 zle -N _lazygit-widget


### PR DESCRIPTION
# 背景

- `terminal-browser`（ターミナル内で動くブラウザ）を日常的に使うため、毎回フルネームを打つのが手間だった
- 起動系のウィジェットは既に `^x^<key>` チョードに揃っている（claude=`^x^a`, codex=`^x^g`）ので、同じ体系で呼び出せるようにしたい

# 概要

- `alias.zsh`: `tb` エイリアスを追加（`command -v tb` が未使用であることを確認済み）
- `bindkey.zsh`: `^x^t` に `_terminal-browser-widget` を割り当て、現在のペインで即 `terminal-browser open` を実行する
  - `^x^t` は zsh デフォルト・現行シェルのいずれでも未使用（`bindkey | grep '\^X\^T'` で確認）
  - 単独キー（`^t` = transpose-chars など）を潰さないようチョードを選択

```mermaid
flowchart LR
    A["Ctrl-x Ctrl-t"] --> B["_terminal-browser-widget"]
    B --> C["BUFFER='terminal-browser open'"]
    C --> D["zle accept-line"]
    D --> E["現在のペインで全画面起動"]
    F["tb ..."] --> G["terminal-browser<br/>(URL 指定などはこちら)"]
```

# 動作確認

- `zsh -n .config/zsh/rc/bindkey.zsh` → syntax OK
- 新規シェルで `Ctrl-x Ctrl-t` からブラウザが起動すること、`tb open localhost:3000` が動作すること
