### PR TITLE
fonts: PlemolJP NF を追加

### DIFF
--- a/.config/brewfile/Brewfile
+++ b/.config/brewfile/Brewfile
@@ -251,6 +251,7 @@ cask chatgpt
 cask discord
 cask docker
 cask font-plemol-jp
+cask font-plemol-jp-nf
 cask ghostty
 cask keycastr
 cask lapce

--- a/install_scripts/lib/dotinstaller/steps/fonts.sh
+++ b/install_scripts/lib/dotinstaller/steps/fonts.sh
@@ -55,6 +55,10 @@ run() {
     "https://github.com/tonsky/FiraCode/releases/download/6.2/Fira_Code_v6.2.zip" \
     "0949915ba8eb24d89fd93d10a7ff623f42830d7c5ffc3ecbf960e4ecad3e3e79"
 
+  fetch_font "PlemolJPNF" \
+    "https://github.com/yuru7/PlemolJP/releases/download/v3.0.0/PlemolJP_NF_v3.0.0.zip" \
+    "887e2d0db714d41ac26ab924bdd3a172b922f57b2b480af01e0147180eac3d80"
+
   if command -v fc-cache >/dev/null 2>&1; then
     fc-cache -vf
   else


### PR DESCRIPTION
# 背景

Codex デスクトップアプリの in-app terminal で neovim を起動すると、devicons などの Nerd Font グリフがすべて豆腐になっていた。

原因はフォント。アプリ内ターミナルは Electron 上の xterm.js で、等幅フォントの既定値に Nerd Font が含まれていない。

```
--font-mono: "SF Mono", "SFMono-Regular", ui-monospace, consolas, liberation mono, menlo, monospace
```

Nerd Font アイコンは Unicode の私用領域 (PUA) を使うが、Chromium は PUA に対して自動フォントフォールバックをほぼ効かせないため、Hack Nerd Font がインストール済みでも描画されない。

アプリ側は `chromeTheme.fonts.code` にフォントを指定すれば xterm に反映されることが分かったが、手元に入っていた Nerd Font は Hack のみで、Hack は Latin 専用のため日本語グリフを持たない。

```mermaid
flowchart LR
  A["Hack Nerd Font Mono<br/>ASCII + アイコン"] --> C{"ターミナル<br/>セル幅"}
  B["PlemolJP Console<br/>日本語"] --> C
  C --> D["先頭フォントから<br/>セル幅を算出<br/>→ 全角が 2 セルに<br/>収まらず桁ズレ"]
```

2 フォントを並べると、xterm.js はセル幅を先頭フォントから測る一方で全角グリフは後続フォント自身の設計比率に従うため、罫線や表がズレる。ASCII・日本語・Nerd Font を 1 つのフォントで賄うのが確実なので、PlemolJP NF を導入する。

# 概要

- `install_scripts/lib/dotinstaller/steps/fonts.sh` に PlemolJP NF v3.0.0 を追加
  - 既存の UDEVGothic / HackNerdFont / FiraCode と同じ `fetch_font` 形式
  - sha256 は実際にダウンロードして算出した値
  - cask は macOS 限定のため、こちらで Linux 側もカバーする
- `.config/brewfile/Brewfile` に `cask font-plemol-jp-nf` をアルファベット順で追加

```mermaid
flowchart TD
  S["./setup.sh --install"] --> M{OS}
  M -->|macOS| BF["brewfile step<br/>cask font-plemol-jp-nf"]
  M -->|macOS / Linux 共通| FS["fonts step<br/>fetch_font PlemolJPNF"]
  BF --> R["~/Library/Fonts/"]
  FS --> L["~/.local/share/fonts/PlemolJPNF/"]
```

# 動作確認

- `brew install --cask font-plemol-jp-nf`
- `fc-cache -f && fc-list : family | grep 'PlemolJP Console NF'` でファミリ名を確認
- `bash -n install_scripts/lib/dotinstaller/steps/fonts.sh`
- Codex アプリ側は `~/.codex/config.toml` に以下を設定して反映を確認（本 PR の範囲外、リポジトリ管理下ではない）

```toml
[desktop.appearanceDarkChromeTheme.fonts]
code = "PlemolJP Console NF"
```

# 補足

合字は引き続き効かない。Codex アプリは `@xterm/addon-ligatures` をロードしておらず、xterm.js 単体に合字機能はないため、フォント側では解決できない。
