### PR TITLE
zellij: zellagent プラグインの参照を削除

### DIFF
--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -254,7 +254,7 @@ plugins {
     session-manager location="zellij:session-manager"
     status-bar location="zellij:status-bar"
     strider location="zellij:strider"
-    tab-bar location="file:~/.config/zellij/plugins/zellagent.wasm"
+    tab-bar location="zellij:tab-bar"
 }
 
 // Plugins to load in the background when a new session starts

--- a/.config/zellij/layouts/default.kdl
+++ b/.config/zellij/layouts/default.kdl
@@ -1,9 +1,0 @@
-// Default layout with zellagent tab status.
-layout {
-    default_tab_template {
-        pane size=1 borderless=true {
-            plugin location="file:~/.config/zellij/plugins/zellagent.wasm"
-        }
-        children
-    }
-}


### PR DESCRIPTION
# 背景

[#80](https://github.com/urugus/dotfiles/pull/80) で signalbox.nvim / herdr を導入した結果、自作の zellagent（Zellij タブバー用 wasm プラグイン）と役割が完全に重複した。両方のフックが同時に走る二重通知の状態になっていたため、zellagent 側を廃止する。

```mermaid
flowchart LR
    subgraph before["Before"]
        C1["claude / codex"] --> ZA["zellagent hook"] --> ZB["Zellij tab-bar<br/>(自作 wasm)"]
        C1 --> HA["herdr hook"] --> HB["signalbox.nvim"]
    end
```

`~/.claude/settings.json` では 10 イベント、`~/.codex/hooks.json` では 8 イベントに zellagent フックが刺さっていた。

# 概要

zellij 設定から zellagent への参照を除去し、組み込みの tab-bar に戻す。

| ファイル | 変更 |
| --- | --- |
| `.config/zellij/config.kdl` | `tab-bar` を `zellij:tab-bar` へ戻す（zellagent 導入前の値） |
| `.config/zellij/layouts/default.kdl` | 削除 |

## layouts/default.kdl を削除した理由

このファイルは初回コミット `c0177dd zellij: add default layout with zellaude plugin` からプラグイン読み込み専用で、他の役割を持ったことがない。

```
c0177dd zellij: add default layout with zellaude plugin
9088d53 zellij: use zellagent tab status
19e3753 zellij: use zellagent tab-bar alias
8160325 zellij: load zellagent plugin directly
```

プラグインを外すと空の器だけが残るため、ファイルごと削除して zellij 組み込みのデフォルトレイアウトにフォールバックさせた。

**挙動の差分**: 組み込みデフォルトは tab-bar に加えて status-bar も表示する。従来のカスタムレイアウトは tab-bar のみだったため、画面下部に status-bar が増える。不要なら `default_tab_template` で `zellij:tab-bar` のみを指定したレイアウトに差し替える。

# リポジトリ管理外で実施した作業

この PR の差分には含まれないが、併せて実施済み:

- `~/.claude/settings.json` — zellagent フックを除去（バックアップ: `settings.json.bak.pre-zellagent-removal`）
- `~/.codex/hooks.json` — 同上（バックアップ: `hooks.json.bak.pre-zellagent-removal`）
- zellagent 本体を private リポジトリへ退避: https://github.com/urugus/zellagent （21 コミット全て push 済み、remote が無く未バックアップだったため）

セキュリティガード（`aws-readonly-guard` / `guard-bash-command` / `guard-file-access`）、second-brain セッションフック、herdr のフックは維持。

# 検証

```
zellij setup --check
  [CONFIG FILE]: Well defined.
```

`.config/` `install_scripts/` 配下に `zellagent` / `zellaude` の参照が残っていないことを grep で確認済み。

# 関連情報

- 前段の PR: https://github.com/urugus/dotfiles/pull/80
- 退避先: https://github.com/urugus/zellagent
