### PR TITLE
neovim: bufferタブを起動時に表示する

### DIFF
--- a/.config/nvim/lua/rc/plugins/ui.lua
+++ b/.config/nvim/lua/rc/plugins/ui.lua
@@ -94,14 +94,7 @@ return {
   },
   {
     "akinsho/bufferline.nvim",
-    cmd = {
-      "BufferLinePick",
-      "BufferLineCyclePrev",
-      "BufferLineCycleNext",
-      "BufferLineMovePrev",
-      "BufferLineMoveNext",
-      "BufferLineGoToBuffer",
-    },
+    event = "VeryLazy",
     dependencies = { "nvim-tree/nvim-web-devicons" },
     config = conf("rc/pluginconfig/bufferline"),
   },


### PR DESCRIPTION
# 背景

- bufferline.nvim の読み込み条件が BufferLine コマンド実行時のみになっており、Neovim 起動時に上部の buffer タブが表示されなくなっていた。

# 概要

- bufferline.nvim の読み込み条件を `VeryLazy` に戻した。
- Neovim の起動後に bufferline が初期化され、上部の buffer タブが表示されるようにした。

# 確認方法

- `stylua --check .config/nvim/lua/rc/plugins/ui.lua`
- headless Neovim で `VeryLazy` 発火後に `loaded=true`、`showtabline=2`、`tabline=%!v:lua.nvim_bufferline()` となることを確認
- `git diff --check`
