### PR TITLE
neovim: SVGプレビューを有効化

### DIFF
--- a/.config/nvim/lua/rc/plugins/tools.lua
+++ b/.config/nvim/lua/rc/plugins/tools.lua
@@ -146,9 +146,10 @@ return {
   {
     "3rd/image.nvim",
     build = false,
-    ft = { "markdown", "norg", "org", "text" },
+    ft = { "markdown", "norg", "org", "svg", "text" },
     opts = {
       processor = "magick_cli",
+      hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp", "*.avif", "*.svg" },
     },
   },
 }


### PR DESCRIPTION
# 背景

- Neovim内でSVGファイルを`image.nvim`によってプレビューできるようにするため。

# 概要

- `image.nvim`の遅延読み込み対象に`svg` filetypeを追加しました。
- 既存の画像形式を維持しつつ、画像バッファとして開く対象に`*.svg`を追加しました。

# 関連情報

- 関連Issueなし

# 確認方法

- `stylua --check .config/nvim/lua/rc/plugins/tools.lua`
- Neovimのヘッドレス起動で、`svg` filetypeと`*.svg`パターンがプラグイン設定に含まれることを確認
- `git diff --check`
