### PR TITLE
neovim: SVGライブプレビューを追加

### DIFF
--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -37,6 +37,7 @@
   "indent-blankline.nvim": { "branch": "master", "commit": "d28a3f70721c79e3c5f6693057ae929f3d9c0a03" },
   "iswap.nvim": { "branch": "master", "commit": "7340d31629f83bf3318159b2388078e2bc387240" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "live-preview.nvim": { "branch": "main", "commit": "a30e54e51e7480d7060c8c8185f2a963ad3518b4" },
   "lspkind-nvim": { "branch": "master", "commit": "c7274c48137396526b59d86232eabcdc7fed8a32" },
   "lspsaga.nvim": { "branch": "main", "commit": "cf6fc9473bba1d332eda9887855ea29ed9b37701" },
   "lualine.nvim": { "branch": "master", "commit": "221ce6b2d999187044529f49da6554a92f740a96" },

--- a/.config/nvim/lua/rc/keymaps/plugins.lua
+++ b/.config/nvim/lua/rc/keymaps/plugins.lua
@@ -398,6 +398,10 @@ return function()
     { { "i", "s" }, "<C-Down>", "<Plug>luasnip-next-choice", { remap = true } },
 
     ------------------------------------------------------------
+    -- live-preview
+    { "n", "<Leader>p", "<Cmd>LivePreview start<CR>", { desc = "Start live preview" } },
+
+    ------------------------------------------------------------
     -- markdown
     { "n", "<Leader>mt", "<Cmd>RenderMarkdown buf_toggle<CR>" },
 

--- a/.config/nvim/lua/rc/plugins/tools.lua
+++ b/.config/nvim/lua/rc/plugins/tools.lua
@@ -146,10 +146,14 @@ return {
   {
     "3rd/image.nvim",
     build = false,
-    ft = { "markdown", "norg", "org", "svg", "text" },
+    ft = { "markdown", "norg", "org", "text" },
     opts = {
       processor = "magick_cli",
-      hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp", "*.avif", "*.svg" },
     },
+  },
+  {
+    "brianhuster/live-preview.nvim",
+    cmd = "LivePreview",
+    dependencies = { "folke/snacks.nvim" },
   },
 }


### PR DESCRIPTION
# 背景

- `image.nvim`とImageMagickによるSVG表示では、埋め込みフォントや長い行を含むSVGを安定してプレビューできなかったため。

# 概要

- SVGプレビューをブラウザのネイティブ描画へ切り替えるため、`live-preview.nvim`を追加しました。
- `image.nvim`からSVG専用の読み込み・ファイルパターン設定を削除しました。
- 現在のファイルをプレビューする`<Leader>p`キーマップを追加しました。

# 関連情報

- 関連Issueなし

# 確認方法

- `stylua --check .config/nvim/lua/rc/keymaps/plugins.lua .config/nvim/lua/rc/plugins/tools.lua`
- `selene --config selene.toml .config/nvim/lua/rc/keymaps/plugins.lua .config/nvim/lua/rc/plugins/tools.lua`
- Neovimのヘッドレス起動で`:LivePreview`の登録・遅延読み込みを確認
- Neovimのヘッドレス起動で`<Leader>p`のコマンドと説明を確認
- `jq empty .config/nvim/lazy-lock.json`
- `git diff --check`
